### PR TITLE
Use automatic instance management

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@
 Most SQL-driven datasources, like `Postgres`, `MySQL`, and `MSSQL` share extremely similar codebases.
 
 The `sqlds` package is intended to remove the repitition of these datasources and centralize the datasource logic. The only thing that the datasources themselves should have to define is connecting to the database, and what driver to use, and the plugin frontend.
+
+**Usage**
+
+```go
+ds := sqlds.NewDatasource(&myDatasource{})
+if err := datasource.Manage("my-datasource", ds.NewDatasource, datasource.ManageOpts{}); err != nil {
+  log.DefaultLogger.Error(err.Error())
+  os.Exit(1)
+}
+```

--- a/datasource.go
+++ b/datasource.go
@@ -6,17 +6,11 @@ import (
 	"sync"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/pkg/errors"
 )
 
-// Datasource contains the entrypoints / handlers for the plugin, and manages the plugin instance
-type Datasource struct {
-	im instancemgmt.InstanceManager
-	c  Driver
-}
 
 type sqldatasource struct {
 	db       *sql.DB
@@ -26,31 +20,27 @@ type sqldatasource struct {
 
 // NewDatasource creates a new `sqldatasource`.
 // It uses the provided settings argument to call the ds.Driver to connect to the SQL server
-func (ds *Datasource) NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+func (ds *sqldatasource) NewDatasource(settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 	db, err := ds.c.Connect(settings)
 	if err != nil {
 		return nil, err
 	}
-
-	return &sqldatasource{
-		db:       db,
-		c:        ds.c,
-		settings: settings,
-	}, nil
+	ds.db = db
+ 	ds.settings = settings
+	
+	 return ds, nil
 }
 
 // NewDatasource initializes the Datasource wrapper and instance manager
-func NewDatasource(c Driver) datasource.ServeOpts {
-	ds := &Datasource{
+func NewDatasource(c Driver) *sqldatasource {
+	return &sqldatasource{
 		c: c,
 	}
+}
 
-	ds.im = datasource.NewInstanceManager(ds.NewDatasource)
 
-	return datasource.ServeOpts{
-		QueryDataHandler:   ds,
-		CheckHealthHandler: ds,
-	}
+// Dispose cleans up datasource instance resources.
+func (ds *sqldatasource) Dispose() {
 }
 
 // QueryData creates the Responses list and executes each query
@@ -128,35 +118,4 @@ func (ds *sqldatasource) CheckHealth(ctx context.Context, req *backend.CheckHeal
 		Status:  backend.HealthStatusOk,
 		Message: "Data source is working",
 	}, nil
-}
-
-// QueryData calls the wrapped instance's QueryData function
-func (ds *Datasource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	h, err := ds.im.Get(req.PluginContext)
-	if err != nil {
-		return nil, err
-	}
-
-	if val, ok := h.(*sqldatasource); ok {
-		return val.QueryData(ctx, req)
-	}
-
-	return nil, ErrorBadDatasource
-}
-
-// CheckHealth calls the wrapped instance's CheckHealth function
-func (ds *Datasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	h, err := ds.im.Get(req.PluginContext)
-	if err != nil {
-		return &backend.CheckHealthResult{
-			Status:  backend.HealthStatusError,
-			Message: err.Error(),
-		}, nil
-	}
-
-	if val, ok := h.(*sqldatasource); ok {
-		return val.CheckHealth(ctx, req)
-	}
-
-	return nil, ErrorBadDatasource
 }

--- a/datasource.go
+++ b/datasource.go
@@ -41,6 +41,7 @@ func NewDatasource(c Driver) *sqldatasource {
 
 // Dispose cleans up datasource instance resources.
 func (ds *sqldatasource) Dispose() {
+	ds.db.Close()
 }
 
 // QueryData creates the Responses list and executes each query


### PR DESCRIPTION
Use automatic instance management to simplify sqlds code a bit and to enable debug support in host plugin. Maybe this could have been introduced in a way that is also backwards compatible with the [manage](https://github.com/grafana/grafana-plugin-sdk-go/blob/master/backend/datasource/manage.go#L17) signature? On the other hand, it might be a good time to introduce breaking changes now that there's still not that many consumers of this package. WDYT? 