### PR TITLE
Allow to add any route

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -20,6 +20,7 @@ type sqldatasource struct {
 
 	backend.CallResourceHandler
 	Completable
+	CustomRoutes map[string]func(http.ResponseWriter, *http.Request)
 }
 
 // NewDatasource creates a new `sqldatasource`.
@@ -32,7 +33,10 @@ func (ds *sqldatasource) NewDatasource(settings backend.DataSourceInstanceSettin
 	ds.db = db
 	ds.settings = settings
 	mux := http.NewServeMux()
-	ds.registerRoutes(mux)
+	err = ds.registerRoutes(mux)
+	if err != nil {
+		return nil, err
+	}
 	ds.CallResourceHandler = httpadapter.New(mux)
 
 	return ds, nil


### PR DESCRIPTION
We want to list custom resources in the sql datasource (like `regions` for AWS plugins). Since these routes/resources are not generic, this PR adds the possibility to set any custom route. More context [here](https://github.com/grafana/athena-datasource/issues/6#issuecomment-885438518).