### PR TITLE
Add query args to be able to modify the current DB

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -112,12 +112,12 @@ func (ds *sqldatasource) getDB(q *Query) (*sql.DB, string, error) {
 		return db.(*sql.DB), key, nil
 	}
 
-	var err error
-	key = string(q.ConnectionArgs[:])
+	key = string(q.ConnectionArgs)
 	if cachedDB, ok := ds.dbConnections.Load(key); ok {
 		return cachedDB.(*sql.DB), key, nil
 	}
 
+	var err error
 	db, err = ds.c.Connect(ds.settings, q.ConnectionArgs)
 	if err != nil {
 		return nil, "", err
@@ -176,10 +176,10 @@ func (ds *sqldatasource) handleQuery(ctx context.Context, req backend.DataQuery)
 
 	if errors.Is(err, ErrorQuery) {
 		db, err = ds.c.Connect(ds.settings, q.ConnectionArgs)
-		ds.dbConnections.Store(cacheKey, db)
 		if err != nil {
 			return nil, err
 		}
+		ds.dbConnections.Store(cacheKey, db)
 
 		return query(ctx, db, ds.c.Converters(), fillMode, q)
 	}

--- a/datasource.go
+++ b/datasource.go
@@ -37,7 +37,7 @@ func (ds *sqldatasource) NewDatasource(settings backend.DataSourceInstanceSettin
 	if err != nil {
 		return nil, err
 	}
-	ds.dbConnections.Store(defaultKey, db) // = map[string]*sql.DB{"": db}
+	ds.dbConnections.Store(defaultKey, db)
 	ds.settings = settings
 	mux := http.NewServeMux()
 	err = ds.registerRoutes(mux)

--- a/datasource.go
+++ b/datasource.go
@@ -146,7 +146,7 @@ func (ds *sqldatasource) handleQuery(req backend.DataQuery) (data.Frames, error)
 		if err != nil {
 			return nil, err
 		}
-		return query(db, ds.c.Converters(), fillMode, q)
+		return query(ds.dbConnections[cacheKey], ds.c.Converters(), fillMode, q)
 	}
 
 	return nil, err

--- a/datasource.go
+++ b/datasource.go
@@ -108,7 +108,7 @@ func (ds *sqldatasource) getDB(q *Query) (*sql.DB, string, error) {
 	if !ok {
 		return nil, "", fmt.Errorf("unable to get default db connection")
 	}
-	if ds.EnableMultipleConnections || len(q.ConnectionArgs) == 0 {
+	if !ds.EnableMultipleConnections || len(q.ConnectionArgs) == 0 {
 		return db.(*sql.DB), key, nil
 	}
 

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -1,0 +1,111 @@
+package sqlds
+
+import (
+	"database/sql"
+	"encoding/json"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+type fakeDriver struct {
+	db *sql.DB
+
+	Driver
+}
+
+func (d *fakeDriver) Connect(backend.DataSourceInstanceSettings, json.RawMessage) (db *sql.DB, err error) {
+	return d.db, nil
+}
+
+func Test_getDB(t *testing.T) {
+	db := &sql.DB{}
+	d := &fakeDriver{db: db}
+	tests := []struct {
+		desc string
+		args string
+		ds   *sqldatasource
+		db   *sql.DB
+	}{
+		{
+			"it should return the default db wiht no args",
+			"",
+			&sqldatasource{
+				dbConnections: map[string]*sql.DB{
+					"": db,
+				},
+			},
+			db,
+		},
+		{
+			"it should return the cached connection for the given args",
+			"foo",
+			&sqldatasource{
+				dbConnections: map[string]*sql.DB{
+					"foo": db,
+				},
+			},
+			db,
+		},
+		{
+			"it should create a new connection with the given args",
+			"foo",
+			&sqldatasource{
+				c:             d,
+				dbConnections: map[string]*sql.DB{},
+			},
+			db,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			res, key, err := tt.ds.getDB(&Query{Args: json.RawMessage(tt.args)})
+			if err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+			if key != tt.args {
+				t.Fatalf("unexpected cache key %s", key)
+			}
+			if res != tt.db {
+				t.Fatalf("unexpected result %v", res)
+			}
+		})
+	}
+}
+
+func Test_Dispose(t *testing.T) {
+	t.Run("it should close all db connections", func(t *testing.T) {
+		db1, mock1, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+		db2, mock2, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		}
+
+		ds := &sqldatasource{
+			dbConnections: map[string]*sql.DB{
+				"":    db1,
+				"foo": db2,
+			},
+		}
+		mock1.ExpectClose()
+		mock2.ExpectClose()
+		ds.Dispose()
+
+		err = mock1.ExpectationsWereMet()
+		if err != nil {
+			t.Error(err)
+		}
+		err = mock2.ExpectationsWereMet()
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(ds.dbConnections) != 0 {
+			t.Errorf("db connections were not deleted: %v", ds.dbConnections)
+		}
+	})
+}

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -29,7 +29,7 @@ func Test_getDB(t *testing.T) {
 		db   *sql.DB
 	}{
 		{
-			"it should return the default db wiht no args",
+			"it should return the default db with no args",
 			"",
 			&sqldatasource{
 				dbConnections: map[string]*sql.DB{

--- a/driver.go
+++ b/driver.go
@@ -2,6 +2,7 @@ package sqlds
 
 import (
 	"database/sql"
+	"encoding/json"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -12,7 +13,8 @@ import (
 // Plugin creators will need to implement this in order to create a managed datasource
 type Driver interface {
 	// Connect connects to the database. It does not need to call `db.Ping()`
-	Connect(backend.DataSourceInstanceSettings) (*sql.DB, error)
+	// Optionally, it receives a JSON object with query arguments to configure the connection
+	Connect(backend.DataSourceInstanceSettings, json.RawMessage) (*sql.DB, error)
 	FillMode() *data.FillMissing
 	Macros() Macros
 	Converters() []sqlutil.Converter

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/grafana/sqlds
 go 1.15
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/grafana/grafana-plugin-sdk-go v0.94.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=

--- a/macros_test.go
+++ b/macros_test.go
@@ -1,28 +1,17 @@
 package sqlds
 
 import (
-	"database/sql"
 	"fmt"
 	"testing"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type MockDB struct{}
+type MockDB struct {
+	Driver
+}
 
-func (h *MockDB) Connect(backend.DataSourceInstanceSettings) (db *sql.DB, err error) {
-	return
-}
-func (h *MockDB) FillMode() (mode *data.FillMissing) {
-	return
-}
-func (h *MockDB) Converters() (sc []sqlutil.Converter) {
-	return
-}
 func (h *MockDB) Macros() (macros Macros) {
 	return map[string]MacroFunc{
 		"foo": func(query *Query, args []string) (out string, err error) {

--- a/query.go
+++ b/query.go
@@ -25,9 +25,9 @@ const (
 // For the sake of backwards compatibility, when making changes to this type, ensure that changes are
 // only additive.
 type Query struct {
-	RawSQL string            `json:"rawSql"`
-	Format FormatQueryOption `json:"format"`
-	Args   json.RawMessage   `json:"args"`
+	RawSQL         string            `json:"rawSql"`
+	Format         FormatQueryOption `json:"format"`
+	ConnectionArgs json.RawMessage   `json:"connectionArgs"`
 
 	RefID         string            `json:"-"`
 	Interval      time.Duration     `json:"-"`
@@ -45,16 +45,16 @@ type Query struct {
 // This is mostly useful in the Interpolate function, where the RawSQL value is modified in a loop
 func (q *Query) WithSQL(query string) *Query {
 	return &Query{
-		RawSQL:        query,
-		Args:          q.Args,
-		RefID:         q.RefID,
-		Interval:      q.Interval,
-		TimeRange:     q.TimeRange,
-		MaxDataPoints: q.MaxDataPoints,
-		FillMissing:   q.FillMissing,
-		Schema:        q.Schema,
-		Table:         q.Table,
-		Column:        q.Column,
+		RawSQL:         query,
+		ConnectionArgs: q.ConnectionArgs,
+		RefID:          q.RefID,
+		Interval:       q.Interval,
+		TimeRange:      q.TimeRange,
+		MaxDataPoints:  q.MaxDataPoints,
+		FillMissing:    q.FillMissing,
+		Schema:         q.Schema,
+		Table:          q.Table,
+		Column:         q.Column,
 	}
 }
 
@@ -68,17 +68,17 @@ func GetQuery(query backend.DataQuery) (*Query, error) {
 
 	// Copy directly from the well typed query
 	return &Query{
-		RawSQL:        model.RawSQL,
-		Format:        model.Format,
-		Args:          model.Args,
-		RefID:         query.RefID,
-		Interval:      query.Interval,
-		TimeRange:     query.TimeRange,
-		MaxDataPoints: query.MaxDataPoints,
-		FillMissing:   model.FillMissing,
-		Schema:        model.Schema,
-		Table:         model.Table,
-		Column:        model.Column,
+		RawSQL:         model.RawSQL,
+		Format:         model.Format,
+		ConnectionArgs: model.ConnectionArgs,
+		RefID:          query.RefID,
+		Interval:       query.Interval,
+		TimeRange:      query.TimeRange,
+		MaxDataPoints:  query.MaxDataPoints,
+		FillMissing:    model.FillMissing,
+		Schema:         model.Schema,
+		Table:          model.Table,
+		Column:         model.Column,
 	}, nil
 }
 

--- a/query.go
+++ b/query.go
@@ -25,9 +25,9 @@ const (
 // For the sake of backwards compatibility, when making changes to this type, ensure that changes are
 // only additive.
 type Query struct {
-	RawSQL string                 `json:"rawSql"`
-	Format FormatQueryOption      `json:"format"`
-	Args   map[string]interface{} `json:"args"`
+	RawSQL string            `json:"rawSql"`
+	Format FormatQueryOption `json:"format"`
+	Args   json.RawMessage   `json:"args"`
 
 	RefID         string            `json:"-"`
 	Interval      time.Duration     `json:"-"`

--- a/query.go
+++ b/query.go
@@ -25,8 +25,9 @@ const (
 // For the sake of backwards compatibility, when making changes to this type, ensure that changes are
 // only additive.
 type Query struct {
-	RawSQL string            `json:"rawSql"`
-	Format FormatQueryOption `json:"format"`
+	RawSQL string                 `json:"rawSql"`
+	Format FormatQueryOption      `json:"format"`
+	Args   map[string]interface{} `json:"args"`
 
 	RefID         string            `json:"-"`
 	Interval      time.Duration     `json:"-"`
@@ -45,6 +46,7 @@ type Query struct {
 func (q *Query) WithSQL(query string) *Query {
 	return &Query{
 		RawSQL:        query,
+		Args:          q.Args,
 		RefID:         q.RefID,
 		Interval:      q.Interval,
 		TimeRange:     q.TimeRange,
@@ -68,6 +70,7 @@ func GetQuery(query backend.DataQuery) (*Query, error) {
 	return &Query{
 		RawSQL:        model.RawSQL,
 		Format:        model.Format,
+		Args:          model.Args,
 		RefID:         query.RefID,
 		Interval:      query.Interval,
 		TimeRange:     query.TimeRange,


### PR DESCRIPTION
Fixes #20

This PR allows to change the datasource database based on the `Query` `Args`. At the moment, this is implemented as a backward-compatible change. If the datasource implements the `DB` function, that will be used to retrieve the database, passing the query as an argument. If not the behavior is the same than before.

Note that this is something generic, it make sense, for a datasource, to send the database name as part of the query so people can reuse the same datasource credentials to connect to different databases. If we want to give this feature a more exposed support, we could change the [`Connect` interface](https://github.com/grafana/sqlds/blob/main/driver.go#L15) to add an optional parameter (the Query args) or add the `DB` method to the interface, but that would be a breaking change. WDYT?