### PR TITLE
Update import path to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/grafana/sqlds
+module github.com/grafana/sqlds/v2
 
 go 1.15
 


### PR DESCRIPTION
This is necessary in order to use v2:

https://github.com/golang/go/wiki/Modules#semantic-import-versioning