### PR TITLE
add tests for query timeout

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
     image: golang:1.16
     environment:
       INTEGRATION_TESTS: "true"
-      MYSQL_URL: "tcp://mysql:mysql@mysql:3306/mysql"
+      MYSQL_URL: "mysql:mysql@tcp(mysql:3306)/mysql"
     commands:
       - go test ./...
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
     image: golang:1.16
     environment:
       INTEGRATION_TESTS: "true"
-      MYSQL_URL: "mysql:mysql@mysql/mysql"
+      MYSQL_URL: "tcp://mysql:mysql@mysql:3306/mysql"
     commands:
       - go test ./...
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,9 +7,25 @@ platform:
   os: linux
   arch: amd64
 
+services:
+  - image: mysql:8.0
+    name: "mysql"
+    environment:
+      MYSQL_USER: mysql
+      MYSQL_PASSWORD: mysql
+      MYSQL_DATABASE: mysql
+      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+
 steps:
   - name: "test"
     image: golang:1.16
+    commands:
+      - go test ./...
+  - name: "integraiton_tests"
+    image: golang:1.16
+    environment:
+      INTEGRATION_TESTS: "true"
+      MYSQL_URL: "mysql:mysql@mysql/mysql"
     commands:
       - go test ./...
 

--- a/driver.go
+++ b/driver.go
@@ -1,6 +1,7 @@
 package sqlds
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"time"
@@ -24,4 +25,13 @@ type Driver interface {
 	Settings(backend.DataSourceInstanceSettings) DriverSettings
 	Macros() Macros
 	Converters() []sqlutil.Converter
+}
+
+// Connection represents a SQL connection and is satisfied by the *sql.DB type
+// For now, we only add the functions that we need / actively use. Some other candidates for future use could include the ExecContext and BeginTxContext functions
+type Connection interface {
+	Close() error
+	Ping() error
+	PingContext(ctx context.Context) error
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,10 @@ go 1.15
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
+	github.com/go-sql-driver/mysql v1.4.0
 	github.com/grafana/grafana-plugin-sdk-go v0.94.0
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+	golang.org/x/text v0.3.6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,7 @@ github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgO
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-sql-driver/mysql v1.4.0 h1:7LxgVwFb2hIQtMm87NdgAVfXjnt4OePseqT1tKx+opk=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
@@ -371,8 +372,9 @@ golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -404,13 +406,17 @@ golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 h1:46ULzRKLh1CwgRq2dC5SlBzEqqNCi8rreOZnNrbqcIY=
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -437,6 +443,7 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/query_integration_test.go
+++ b/query_integration_test.go
@@ -1,0 +1,75 @@
+package sqlds
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+type testArgs struct {
+	MySQLURL            string
+	RunIntegrationTests bool
+}
+
+func testEnvArgs(t *testing.T) testArgs {
+	t.Helper()
+	var args testArgs
+	if val, ok := os.LookupEnv("MYSQL_URL"); ok {
+		args.MySQLURL = val
+	} else {
+		args.MySQLURL = "mysql:mysql@/mysql"
+	}
+
+	if _, ok := os.LookupEnv("INTEGRATION_TESTS"); ok {
+		args.RunIntegrationTests = true
+	}
+
+	return args
+}
+
+func TestQuery_MySQL(t *testing.T) {
+	var (
+		args = testEnvArgs(t)
+		ctx  = context.Background()
+	)
+
+	if !args.RunIntegrationTests {
+		t.SkipNow()
+	}
+
+	db, err := sql.Open("mysql", args.MySQLURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("The query should return a context.Canceled if it exceeds the timeout", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+
+		q := &Query{
+			RawSQL: "SELECT SLEEP(5)",
+		}
+
+		_, err := query(ctx, db, []sqlutil.Converter{}, nil, q)
+		if err == nil {
+			t.Fatal("expected an error but received none")
+		}
+		if !(errors.Is(err, context.Canceled) || strings.Contains(err.Error(), "context deadline exceeded")) {
+			t.Fatal("expected a context.Canceled error but received:", err)
+		}
+	})
+}

--- a/query_integration_test.go
+++ b/query_integration_test.go
@@ -39,17 +39,27 @@ func TestQuery_MySQL(t *testing.T) {
 	var (
 		args = testEnvArgs(t)
 		ctx  = context.Background()
+
+		db *sql.DB
 	)
 
 	if !args.RunIntegrationTests {
 		t.SkipNow()
 	}
 
-	db, err := sql.Open("mysql", args.MySQLURL)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
 
+	limit := 10
+	for i := 0; i < limit; i++ {
+		d, err := sql.Open("mysql", args.MySQLURL)
+		if err == nil {
+			db = d
+			break
+		}
+
+		<-ticker.C
+	}
 	defer db.Close()
 
 	if err := db.Ping(); err != nil {

--- a/query_integration_test.go
+++ b/query_integration_test.go
@@ -47,9 +47,10 @@ func TestQuery_MySQL(t *testing.T) {
 		t.SkipNow()
 	}
 
-	ticker := time.NewTicker(time.Second)
+	ticker := time.NewTicker(time.Second * 5)
 	defer ticker.Stop()
 
+	// Attempt to connect multiple times because these tests are ran in Drone, where the mysql server may not be immediately available when this test is ran.
 	limit := 10
 	for i := 0; i < limit; i++ {
 		d, err := sql.Open("mysql", args.MySQLURL)

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,106 @@
+package sqlds
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+)
+
+var (
+	errorPingCompleted  = errors.New("ping completed")
+	errorQueryCompleted = errors.New("query completed")
+)
+
+type testConnection struct {
+	PingWait time.Duration
+
+	QueryWait     time.Duration
+	QueryRunCount int
+}
+
+func (t *testConnection) Close() error {
+	t.QueryRunCount = 0
+	return nil
+}
+
+func (t *testConnection) Ping() error {
+	return errorPingCompleted
+}
+
+func (t *testConnection) PingContext(ctx context.Context) error {
+	done := make(chan bool)
+	go func() {
+		time.Sleep(t.QueryWait)
+		done <- true
+	}()
+
+	select {
+	case <-ctx.Done():
+		return context.Canceled
+	case <-done:
+		return errorPingCompleted
+	}
+}
+
+func (t *testConnection) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	t.QueryRunCount++
+
+	done := make(chan bool)
+	go func() {
+		time.Sleep(t.QueryWait)
+		done <- true
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, context.Canceled
+	case <-done:
+		return nil, errorQueryCompleted
+	}
+}
+
+func TestQuery_Timeout(t *testing.T) {
+	t.Run("it should return context.Canceled if the query timeout is exceeded", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+		defer cancel()
+
+		conn := &testConnection{
+			PingWait:  time.Second * 5,
+			QueryWait: time.Second * 5,
+		}
+
+		defer conn.Close()
+
+		_, err := query(ctx, conn, []sqlutil.Converter{}, nil, &Query{})
+
+		if !errors.Is(err, context.Canceled) {
+			t.Fatal("expected error to be context.Canceled, received", err)
+		}
+
+		if conn.QueryRunCount != 1 {
+			t.Fatal("expected the querycontext function to run only once, but ran", conn.QueryRunCount, "times")
+		}
+	})
+
+	t.Run("it should run to completion and not return a query timeout error", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+		defer cancel()
+
+		conn := &testConnection{
+			PingWait:  time.Second,
+			QueryWait: time.Second,
+		}
+
+		defer conn.Close()
+
+		_, err := query(ctx, conn, []sqlutil.Converter{}, nil, &Query{})
+
+		if !errors.Is(err, ErrorQuery) {
+			t.Fatal("expected function to complete, received error: ", err)
+		}
+	})
+}


### PR DESCRIPTION
Before this PR i really couldn't think of a good way to write tests for a `sql.DB` or `QueryContext` without importing a package like `sqlmock`. I've had a lot of trouble with sqlmock in the past.

I figured accepting an interface instead of a *sql.DB makes this testing process a lot easier. Let me know if there's anything else I should test while I'm in here.

Arguably this test itself isn't super valuable but at the very least it ensures that if the context in `db.QueryRowContext` is canceled, the cancellation causes an error to be returned by the `query` function.