### PR TITLE
Add support for logs format

### DIFF
--- a/query.go
+++ b/query.go
@@ -20,7 +20,7 @@ const (
 	FormatOptionTimeSeries FormatQueryOption = iota
 	// FormatOptionTable formats the query results as a table using "LongToWide"
 	FormatOptionTable
-	// FormatOptionLogs formats the query as FormatOptionTable
+	// FormatOptionLogs sets the preferred visualization to logs
 	FormatOptionLogs
 )
 

--- a/query.go
+++ b/query.go
@@ -20,6 +20,8 @@ const (
 	FormatOptionTimeSeries FormatQueryOption = iota
 	// FormatOptionTable formats the query results as a table using "LongToWide"
 	FormatOptionTable
+	// FormatOptionLogs formats the query as FormatOptionTable
+	FormatOptionLogs
 )
 
 // Query is the model that represents the query that users submit from the panel / queryeditor.
@@ -140,6 +142,11 @@ func getFrames(rows *sql.Rows, limit int64, converters []sqlutil.Converter, fill
 	frame.Meta.ExecutedQueryString = query.RawSQL
 
 	if query.Format == FormatOptionTable {
+		return data.Frames{frame}, nil
+	}
+
+	if query.Format == FormatOptionLogs {
+		frame.Meta.PreferredVisualization = data.VisTypeLogs
 		return data.Frames{frame}, nil
 	}
 


### PR DESCRIPTION
At the moment, if the datasource sets the format to "Logs" (`2`), the frame is formatted as TimeSeries, causing some errors. Also this PR makes sure that the preferred visualization type is set (useful for the "explore" view).
