### PR TITLE
Logs format

### DIFF
--- a/query.go
+++ b/query.go
@@ -21,7 +21,7 @@ const (
 	FormatOptionTimeSeries FormatQueryOption = iota
 	// FormatOptionTable formats the query results as a table using "LongToWide"
 	FormatOptionTable
-	// FormatOptionLogs formats the query results as a table but set the preferred visualization as "Logs"
+	// FormatOptionLogs sets the preferred visualization to logs
 	FormatOptionLogs
 )
 
@@ -167,15 +167,11 @@ func getFrames(rows *sql.Rows, limit int64, converters []sqlutil.Converter, fill
 	}
 
 	frame.Meta.ExecutedQueryString = query.RawSQL
+
 	if query.Format == FormatOptionTable || query.Format == FormatOptionLogs {
 		if query.Format == FormatOptionLogs && isLogFrame(*frame) {
 			frame.Meta.PreferredVisualization = data.VisTypeLogs
 		}
-		return data.Frames{frame}, nil
-	}
-
-	if query.Format == FormatOptionLogs {
-		frame.Meta.PreferredVisualization = data.VisTypeLogs
 		return data.Frames{frame}, nil
 	}
 

--- a/query_test.go
+++ b/query_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -103,4 +105,27 @@ func TestQuery_Timeout(t *testing.T) {
 			t.Fatal("expected function to complete, received error: ", err)
 		}
 	})
+}
+
+func Test_isLogFrame(t *testing.T) {
+	tests := []struct {
+		name     string
+		frame    data.Frame
+		expected bool
+	}{
+		{frame: *data.NewFrameOfFieldTypes("foo", 4)},
+		{frame: *data.NewFrameOfFieldTypes("foo", 4, data.FieldTypeBool)},
+		{frame: *data.NewFrameOfFieldTypes("foo", 4, data.FieldTypeTime)},
+		{frame: *data.NewFrameOfFieldTypes("foo", 4, data.FieldTypeString)},
+		{frame: *data.NewFrameOfFieldTypes("foo", 4, data.FieldTypeString, data.FieldTypeNullableString)},
+		{frame: *data.NewFrameOfFieldTypes("foo", 4, data.FieldTypeString, data.FieldTypeTime), expected: true},
+		{frame: *data.NewFrameOfFieldTypes("foo", 4, data.FieldTypeNullableString, data.FieldTypeNullableString, data.FieldTypeNullableFloat64, data.FieldTypeTime), expected: true},
+		{frame: *data.NewFrameOfFieldTypes("foo", 4, data.FieldTypeNullableString, data.FieldTypeNullableString, data.FieldTypeNullableFloat64)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := isLogFrame(tt.frame)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
 }


### PR DESCRIPTION
Support for logs format

Really a coincidence to @andresmgot 's PR #38 . In addition to #38, this PR also checks if the frame has at least one Time field and one string field as in other cases, it wont render properly in Explorer