### PR TITLE
Update Completable interface with custom options

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -10,6 +10,12 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
+const (
+	schemas = "schemas"
+	tables  = "tables"
+	columns = "columns"
+)
+
 // ErrorNotImplemented is returned if the function is not implemented by the provided Driver (the Completable pointer is nil)
 var ErrorNotImplemented = errors.New("not implemented")
 
@@ -39,83 +45,48 @@ func sendResourceResponse(rw http.ResponseWriter, res []string) {
 	}
 }
 
-func (ds *sqldatasource) getSchemas(rw http.ResponseWriter, req *http.Request) {
-	if ds.Completable == nil {
-		handleError(rw, ErrorNotImplemented)
-		return
-	}
+func (ds *sqldatasource) getResources(rtype string) func(rw http.ResponseWriter, req *http.Request) {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		if ds.Completable == nil {
+			handleError(rw, ErrorNotImplemented)
+			return
+		}
 
-	options := Options{}
-	if req.Body != nil {
-		err := json.NewDecoder(req.Body).Decode(&options)
+		options := Options{}
+		if req.Body != nil {
+			err := json.NewDecoder(req.Body).Decode(&options)
+			if err != nil {
+				handleError(rw, err)
+				return
+			}
+		}
+
+		var res []string
+		var err error
+		switch rtype {
+		case schemas:
+			res, err = ds.Completable.Schemas(req.Context(), options)
+		case tables:
+			res, err = ds.Completable.Tables(req.Context(), options)
+		case columns:
+			res, err = ds.Completable.Columns(req.Context(), options)
+		default:
+			err = fmt.Errorf("unexpected resource type: %s", rtype)
+		}
 		if err != nil {
 			handleError(rw, err)
 			return
 		}
+
+		sendResourceResponse(rw, res)
 	}
-
-	res, err := ds.Completable.Schemas(req.Context(), options)
-	if err != nil {
-		handleError(rw, err)
-		return
-	}
-
-	sendResourceResponse(rw, res)
-}
-
-func (ds *sqldatasource) getTables(rw http.ResponseWriter, req *http.Request) {
-	if ds.Completable == nil {
-		handleError(rw, ErrorNotImplemented)
-		return
-	}
-
-	options := Options{}
-	if req.Body != nil {
-		err := json.NewDecoder(req.Body).Decode(&options)
-		if err != nil {
-			handleError(rw, err)
-			return
-		}
-	}
-
-	res, err := ds.Completable.Tables(req.Context(), options)
-	if err != nil {
-		handleError(rw, err)
-		return
-	}
-
-	sendResourceResponse(rw, res)
-}
-
-func (ds *sqldatasource) getColumns(rw http.ResponseWriter, req *http.Request) {
-	if ds.Completable == nil {
-		handleError(rw, ErrorNotImplemented)
-		return
-	}
-
-	options := Options{}
-	if req.Body != nil {
-		err := json.NewDecoder(req.Body).Decode(&options)
-		if err != nil {
-			handleError(rw, err)
-			return
-		}
-	}
-
-	res, err := ds.Completable.Columns(req.Context(), options)
-	if err != nil {
-		handleError(rw, err)
-		return
-	}
-
-	sendResourceResponse(rw, res)
 }
 
 func (ds *sqldatasource) registerRoutes(mux *http.ServeMux) error {
 	defaultRoutes := map[string]func(http.ResponseWriter, *http.Request){
-		"/tables":  ds.getTables,
-		"/schemas": ds.getSchemas,
-		"/columns": ds.getColumns,
+		"/tables":  ds.getResources(tables),
+		"/schemas": ds.getResources(schemas),
+		"/columns": ds.getResources(columns),
 	}
 	for route, handler := range defaultRoutes {
 		mux.HandleFunc(route, handler)

--- a/completion_test.go
+++ b/completion_test.go
@@ -78,21 +78,21 @@ func TestCompletable(t *testing.T) {
 	}{
 		{
 			"it should return schemas",
-			"schemas",
+			schemas,
 			&fakeCompletable{schemas: map[string][]string{"foobar": {"foo", "bar"}}},
 			`{"database":"foobar"}`,
 			`["foo","bar"]` + "\n",
 		},
 		{
 			"it should return tables of a schema",
-			"tables",
+			tables,
 			&fakeCompletable{tables: map[string][]string{"foobar": {"foo", "bar"}}},
 			`{"schema":"foobar"}`,
 			`["foo","bar"]` + "\n",
 		},
 		{
 			"it should return columns of a table",
-			"columns",
+			columns,
 			&fakeCompletable{columns: map[string][]string{"foobar": {"foo", "bar"}}},
 			`{"table":"foobar"}`,
 			`["foo","bar"]` + "\n",
@@ -106,21 +106,7 @@ func TestCompletable(t *testing.T) {
 			sqlds.Completable = test.fakeImpl
 
 			b := ioutil.NopCloser(bytes.NewReader([]byte(test.reqBody)))
-			switch test.method {
-			case "schemas":
-				sqlds.getSchemas(w, &http.Request{
-					Body: b,
-				})
-			case "tables":
-				sqlds.getTables(w, &http.Request{
-					Body: b,
-				})
-			case "columns":
-				sqlds.getColumns(w, &http.Request{
-					Body: b,
-				})
-			}
-
+			sqlds.getResources(test.method)(w, &http.Request{Body: b})
 			resp := w.Result()
 			body, _ := io.ReadAll(resp.Body)
 


### PR DESCRIPTION
Fixes #46

Note that this is a breaking change since the `Completable` interface has different parameters but the only datasources that use them are the ones I maintain (so I will change them after this PR). Do you think we should bump the major version anyway?