### PR TITLE
Avoid to remove connections when disposing

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -101,15 +101,8 @@ func NewDatasource(c Driver) *sqldatasource {
 }
 
 // Dispose cleans up datasource instance resources.
+// Note: Called when testing and saving a datasource
 func (ds *sqldatasource) Dispose() {
-	ds.dbConnections.Range(func(key, dbConn interface{}) bool {
-		err := dbConn.(dbConnection).db.Close()
-		if err != nil {
-			backend.Logger.Error(err.Error())
-		}
-		ds.dbConnections.Delete(key)
-		return true
-	})
 }
 
 // QueryData creates the Responses list and executes each query

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/grafana/sqlds/v2
 go 1.15
 
 require (
-	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/go-sql-driver/mysql v1.4.0
 	github.com/google/go-cmp v0.5.6
 	github.com/grafana/grafana-plugin-sdk-go v0.94.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
-github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=


### PR DESCRIPTION
The method `Dispose` is only called when creating or updating a data source (not really what can be inferred by its name). Since it was deleting all the connections, when adding a second data source for the same plugin, it was deleting the first connection causing the error described at https://github.com/grafana/redshift-datasource/issues/98.
