### PR TITLE
Refactor regex part of macros

### DIFF
--- a/macros.go
+++ b/macros.go
@@ -141,11 +141,10 @@ func interpolate(driver Driver, query *Query) (string, error) {
 	}
 	rawSQL := query.RawSQL
 	for key, macro := range macros {
-		rgx, err := regexp.Compile(getMacroRegex(key))
+		matches, err := getMatches(key, rawSQL)
 		if err != nil {
 			return rawSQL, err
 		}
-		matches := rgx.FindAllStringSubmatch(rawSQL, -1)
 		for _, match := range matches {
 			if len(match) == 0 {
 				// There were no matches for this macro
@@ -169,4 +168,12 @@ func interpolate(driver Driver, query *Query) (string, error) {
 	}
 
 	return rawSQL, nil
+}
+
+func getMatches(macroName, rawSQL string) ([][]string, error) {
+	rgx, err := regexp.Compile(getMacroRegex(macroName))
+	if err != nil {
+		return nil, err
+	}
+	return rgx.FindAllStringSubmatch(rawSQL, -1), nil
 }

--- a/macros_test.go
+++ b/macros_test.go
@@ -79,3 +79,28 @@ func TestInterpolate(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMacroRegex(t *testing.T) {
+	t.Run("returns composed regular expression", func(t *testing.T) {
+		assert.Equal(t, `\$__some_string\b(?:\((.*?)\))?`, getMacroRegex("some_string"))
+	})
+	t.Run("FindAllStringSubmatch returns DefaultMacros", func(t *testing.T) {
+		for macroName := range DefaultMacros {
+			matches, err := getMatches(macroName, fmt.Sprintf("$__%s", macroName))
+
+			assert.NoError(t, err)
+			assert.Equal(t, [][]string{{fmt.Sprintf("$__%s", macroName), ""}}, matches)
+		}
+	})
+}
+
+func TestGetMacroRegex_returns_composed_regular_expression(t *testing.T) {
+	assert.Equal(t, `\$__some_string\b(?:\((.*?)\))?`, getMacroRegex("some_string"))
+}
+
+func TestGetMatches_does_not_match_for_macro_name_which_is_substring(t *testing.T) {
+	matches, err := getMatches("timeFilter", "$__timeFilterEpoch(time_column)")
+
+	assert.NoError(t, err)
+	assert.Nil(t, matches)
+}

--- a/macros_test.go
+++ b/macros_test.go
@@ -80,10 +80,11 @@ func TestInterpolate(t *testing.T) {
 	}
 }
 
-func TestGetMacroRegex(t *testing.T) {
-	t.Run("returns composed regular expression", func(t *testing.T) {
-		assert.Equal(t, `\$__some_string\b(?:\((.*?)\))?`, getMacroRegex("some_string"))
-	})
+func TestGetMacroRegex_returns_composed_regular_expression(t *testing.T) {
+	assert.Equal(t, `\$__some_string\b(?:\((.*?)\))?`, getMacroRegex("some_string"))
+}
+
+func TestGetMatches(t *testing.T) {
 	t.Run("FindAllStringSubmatch returns DefaultMacros", func(t *testing.T) {
 		for macroName := range DefaultMacros {
 			matches, err := getMatches(macroName, fmt.Sprintf("$__%s", macroName))
@@ -92,15 +93,10 @@ func TestGetMacroRegex(t *testing.T) {
 			assert.Equal(t, [][]string{{fmt.Sprintf("$__%s", macroName), ""}}, matches)
 		}
 	})
-}
+	t.Run("does not return matches for macro name which is substring", func(t *testing.T) {
+		matches, err := getMatches("timeFilter", "$__timeFilterEpoch(time_column)")
 
-func TestGetMacroRegex_returns_composed_regular_expression(t *testing.T) {
-	assert.Equal(t, `\$__some_string\b(?:\((.*?)\))?`, getMacroRegex("some_string"))
-}
-
-func TestGetMatches_does_not_match_for_macro_name_which_is_substring(t *testing.T) {
-	matches, err := getMatches("timeFilter", "$__timeFilterEpoch(time_column)")
-
-	assert.NoError(t, err)
-	assert.Nil(t, matches)
+		assert.NoError(t, err)
+		assert.Nil(t, matches)
+	})
 }


### PR DESCRIPTION
This will extract the matching of macro name and the extraction of fields in rawSQL in a separate function to facilitate testing.