### PR TITLE
Expose query interpolation util

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -174,7 +174,7 @@ func (ds *sqldatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 	}
 
 	// Apply supported macros to the query
-	q.RawSQL, err = interpolate(ds.c, q)
+	q.RawSQL, err = Interpolate(ds.c, q)
 	if err != nil {
 		return getErrorFrameFromQuery(q), fmt.Errorf("%s: %w", "Could not apply macros", err)
 	}

--- a/macros.go
+++ b/macros.go
@@ -131,7 +131,8 @@ func getMacroRegex(name string) string {
 	return fmt.Sprintf("\\$__%s\\b(?:\\((.*?)\\))?", name)
 }
 
-func interpolate(driver Driver, query *Query) (string, error) {
+// Interpolate returns an interpolated query string given a backend.DataQuery
+func Interpolate(driver Driver, query *Query) (string, error) {
 	macros := driver.Macros()
 	for key, defaultMacro := range DefaultMacros {
 		if _, ok := macros[key]; !ok {

--- a/macros_test.go
+++ b/macros_test.go
@@ -73,7 +73,7 @@ func TestInterpolate(t *testing.T) {
 				Table:  tableName,
 				Column: tableColumn,
 			}
-			interpolatedQuery, err := interpolate(&driver, query)
+			interpolatedQuery, err := Interpolate(&driver, query)
 			require.Nil(t, err)
 			assert.Equal(t, tc.output, interpolatedQuery)
 		})


### PR DESCRIPTION
In the BigQuery data source, we have added a query validation endpoint. In order to utilize BigQuery's validation functionality, we need to send an interpolated query to avoid errors caused by unresolved macros.

This PR exposes the Interpolate function from sqlds.