### PR TITLE
Don't retry queries that have exceeded context deadline

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -211,7 +211,9 @@ func (ds *sqldatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 		return res, nil
 	}
 
-	if errors.Is(err, ErrorQuery) {
+	// If there's a query error that didn't exceed the
+	// context deadline retry the query
+	if errors.Is(err, ErrorQuery) && !errors.Is(err, context.DeadlineExceeded) {
 		db, err := ds.c.Connect(dbConn.settings, q.ConnectionArgs)
 		if err != nil {
 			return nil, err

--- a/datasource.go
+++ b/datasource.go
@@ -218,7 +218,11 @@ func (ds *sqldatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 		}
 		ds.storeDBConnection(cacheKey, dbConnection{db, dbConn.settings})
 
-		return query(ctx, db, ds.c.Converters(), fillMode, q)
+		retryRes, retryErr := query(ctx, db, ds.c.Converters(), fillMode, q)
+		if retryErr == nil {
+			return retryRes, nil
+		}
+		return nil, retryErr
 	}
 
 	return nil, err

--- a/datasource.go
+++ b/datasource.go
@@ -218,11 +218,7 @@ func (ds *sqldatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 		}
 		ds.storeDBConnection(cacheKey, dbConnection{db, dbConn.settings})
 
-		retryRes, retryErr := query(ctx, db, ds.c.Converters(), fillMode, q)
-		if retryErr == nil {
-			return retryRes, nil
-		}
-		return nil, retryErr
+		return query(ctx, db, ds.c.Converters(), fillMode, q)
 	}
 
 	return nil, err


### PR DESCRIPTION
This PR fixes an error in which retried queries which themselves return an error are not processed correctly. This can happen on SQL data sources with long running queries that time out (e.g. Snowflake). Resulting response will cause the dashboard to think that frames have been return (even though there aren't any).

The included changes cause the error to be returned sans data frames so that the front-end error is correctly triggered.