### PR TITLE
Improve error handling for invalid queries

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -170,7 +170,7 @@ func (ds *sqldatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 	// Convert the backend.DataQuery into a Query object
 	q, err := GetQuery(req)
 	if err != nil {
-		return getErrorFrameFromQuery(q), err
+		return nil, err
 	}
 
 	// Apply supported macros to the query

--- a/query.go
+++ b/query.go
@@ -67,7 +67,7 @@ func GetQuery(query backend.DataQuery) (*Query, error) {
 	model := &Query{}
 
 	if err := json.Unmarshal(query.JSON, &model); err != nil {
-		return nil, ErrorJSON
+		return nil, fmt.Errorf("%w: %v", ErrorJSON, err)
 	}
 
 	// Copy directly from the well typed query


### PR DESCRIPTION
When the frontend sends an invalid query, the backend plugin will panic because it tries to decode error frames from a nil object. Also, the actual error message from the JSON decoder is not returned or logged. This PR tries to address this.