### PR TITLE
Add interface for long running queries

### DIFF
--- a/datasource_test.go
+++ b/datasource_test.go
@@ -61,10 +61,10 @@ func Test_getDBConnectionFromQuery(t *testing.T) {
 			settings := backend.DataSourceInstanceSettings{UID: tt.dsUID}
 			key := defaultKey(tt.dsUID)
 			// Add the mandatory default db
-			ds.storeDBConnection(key, dbConnection{db, settings})
+			ds.storeDBConnection(key, dbConnection{db: db, settings: settings})
 			if tt.existingDB != nil {
 				key = keyWithConnectionArgs(tt.dsUID, []byte(tt.args))
-				ds.storeDBConnection(key, dbConnection{tt.existingDB, settings})
+				ds.storeDBConnection(key, dbConnection{db: tt.existingDB, settings: settings})
 			}
 
 			key, dbConn, err := ds.getDBConnectionFromQuery(&Query{ConnectionArgs: json.RawMessage(tt.args)}, tt.dsUID)
@@ -83,16 +83,16 @@ func Test_getDBConnectionFromQuery(t *testing.T) {
 	t.Run("it should return an error if connection args are used without enabling multiple connections", func(t *testing.T) {
 		ds := &sqldatasource{c: d, EnableMultipleConnections: false}
 		_, _, err := ds.getDBConnectionFromQuery(&Query{ConnectionArgs: json.RawMessage("foo")}, "dsUID")
-		if err == nil || !errors.Is(err, MissingMultipleConnectionsConfig) {
-			t.Errorf("expecting error: %v", MissingMultipleConnectionsConfig)
+		if err == nil || !errors.Is(err, ErrorMissingMultipleConnectionsConfig) {
+			t.Errorf("expecting error: %v", ErrorMissingMultipleConnectionsConfig)
 		}
 	})
 
 	t.Run("it should return an error if the default connection is missing", func(t *testing.T) {
 		ds := &sqldatasource{c: d}
 		_, _, err := ds.getDBConnectionFromQuery(&Query{}, "dsUID")
-		if err == nil || !errors.Is(err, MissingDBConnection) {
-			t.Errorf("expecting error: %v", MissingDBConnection)
+		if err == nil || !errors.Is(err, ErrorMissingDBConnection) {
+			t.Errorf("expecting error: %v", ErrorMissingDBConnection)
 		}
 	})
 }

--- a/driver.go
+++ b/driver.go
@@ -3,6 +3,7 @@ package sqlds
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"time"
 
@@ -14,6 +15,18 @@ import (
 type DriverSettings struct {
 	Timeout  time.Duration
 	FillMode *data.FillMissing
+}
+
+type AsyncDB interface {
+	StartQuery(ctx context.Context, query string, args ...interface{}) (string, error)
+	GetQueryID(ctx context.Context, query string, args ...interface{}) (bool, string, error)
+	QueryStatus(ctx context.Context, queryID string) (bool, string, error)
+	CancelQuery(ctx context.Context, queryID string) error
+	GetRows(ctx context.Context, queryID string) (driver.Rows, error)
+}
+
+type AsyncDBGetter interface {
+	GetAsyncDB(backend.DataSourceInstanceSettings, json.RawMessage) (AsyncDB, error)
 }
 
 // Driver is a simple interface that defines how to connect to a backend SQL datasource

--- a/driver.go
+++ b/driver.go
@@ -25,10 +25,6 @@ type AsyncDB interface {
 	GetRows(ctx context.Context, queryID string) (driver.Rows, error)
 }
 
-type AsyncDBGetter interface {
-	GetAsyncDB(backend.DataSourceInstanceSettings, json.RawMessage) (AsyncDB, error)
-}
-
 // Driver is a simple interface that defines how to connect to a backend SQL datasource
 // Plugin creators will need to implement this in order to create a managed datasource
 type Driver interface {
@@ -38,6 +34,11 @@ type Driver interface {
 	Settings(backend.DataSourceInstanceSettings) DriverSettings
 	Macros() Macros
 	Converters() []sqlutil.Converter
+}
+
+type AsyncDriver interface {
+	Driver
+	ConnectAsync(backend.DataSourceInstanceSettings, json.RawMessage) (AsyncDB, error)
 }
 
 // Connection represents a SQL connection and is satisfied by the *sql.DB type


### PR DESCRIPTION
Adding interface for plugins to implement for asynchronous queries.

There's some changes to the variables `MissingMultipleConnectionsConfig` and `MissingDBConnection`. I'll open a separate PR for those changes. Only have them in here to fix this warning `... should have name of the form ErrFoo (ST1012) go-staticcheck` while working through this PR.