### PR TITLE
mock driver

### DIFF
--- a/mock/csv_data.go
+++ b/mock/csv_data.go
@@ -1,0 +1,158 @@
+package mock
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+// we could add more "tables" later
+var mockTables = map[string]string{
+	"users": users,
+}
+
+// MockDataFolder is the default folder that will contain data files
+const MockDataFolder = "/mock-data"
+
+// Create will create a "table" (csv file) in the data folder that can be queried with SQL
+func CreateMockTable(table string, folder string) error {
+	return CreateMockData(table, folder, mockTables[table])
+}
+
+// CreateData will create a "table" (csv file) in the data folder that can be queried with SQL
+func CreateMockData(table string, folder string, csvData string) error {
+	if folder == "" {
+		folder = MockDataFolder
+	}
+	ex, err := os.Executable()
+	if err != nil {
+		backend.Logger.Error("failed getting to Hana Mock path: " + err.Error())
+		return err
+	}
+	exPath := filepath.Dir(ex)
+	if _, err := os.Stat(exPath + folder); errors.Is(err, fs.ErrNotExist) {
+		if err := os.Mkdir(exPath+folder, 0700); err != nil {
+			backend.Logger.Error("failed creating mock folder: " + err.Error())
+			return err
+		}
+	}
+	tablePath := exPath + folder + "/" + table
+	_, err = os.Stat(tablePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			if err := os.WriteFile(tablePath, []byte(csvData), 0700); err != nil {
+				backend.Logger.Error("failed writing mock data: " + err.Error())
+				return err
+			}
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+const users = `id,first_name,last_name,gender,country_code
+1,Louis,Washington,Male,PS
+2,Sean,Burton,Male,SE
+3,Mildred,Gonzales,Female,ID
+4,Kathy,Dunn,Female,PE
+5,Brian,Fernandez,Male,ID
+6,Aaron,Alvarez,Male,TN
+7,Theresa,King,Female,PH
+8,Catherine,Greene,Female,ID
+9,Barbara,Sanders,Female,US
+10,John,Garrett,Male,MT
+11,Jerry,Tucker,Male,GT
+12,James,Marshall,Male,PL
+13,Cheryl,Perry,Female,CN
+14,Gregory,Jones,Male,CA
+15,Julie,Olson,Female,JP
+16,Raymond,King,Male,AZ
+17,Christina,Wagner,Female,AR
+18,Evelyn,Harvey,Female,RU
+19,Earl,Stewart,Male,ID
+20,Jerry,Kelley,Male,RU
+21,Russell,Ruiz,Male,ID
+22,Rachel,Reynolds,Female,FR
+23,Anne,Richards,Female,PA
+24,Jimmy,Hudson,Male,GR
+25,Brandon,Ward,Male,BR
+26,Ruby,Stevens,Female,TH
+27,Paula,Jordan,Female,ID
+28,Jessica,Hayes,Female,CN
+29,Kimberly,Butler,Female,AD
+30,Jacqueline,Lee,Female,CN
+31,Heather,Lopez,Female,ID
+32,Cheryl,Burke,Female,AR
+33,Sarah,Ryan,Female,CN
+34,Donna,Kelly,Female,ID
+35,Norma,Davis,Female,ID
+36,Jack,Anderson,Male,CN
+37,Albert,Gibson,Male,PH
+38,Victor,Hayes,Male,SN
+39,Mary,Lynch,Female,MN
+40,Elizabeth,Fernandez,Female,PL
+41,Brenda,Shaw,Female,GR
+42,Jacqueline,Hernandez,Female,RU
+43,Sarah,King,Female,PT
+44,Christine,Nguyen,Female,MC
+45,Johnny,Woods,Male,CN
+46,Dennis,Thompson,Male,RU
+47,Diana,Brooks,Female,CO
+48,Wayne,Morales,Male,CR
+49,Arthur,Howard,Male,PE
+50,Earl,Daniels,Male,ID
+51,Martin,Gonzales,Male,PL
+52,Annie,Palmer,Female,PK
+53,Rose,Griffin,Female,MN
+54,Ruth,Garza,Female,TH
+55,Gerald,Marshall,Male,CZ
+56,Julie,Mills,Female,FI
+57,Julia,Fowler,Female,PS
+58,Bonnie,Dixon,Female,CN
+59,Adam,Mendoza,Male,FR
+60,Brian,Bailey,Male,HR
+61,Linda,Hansen,Female,PL
+62,Edward,Gordon,Male,JP
+63,Pamela,Hill,Female,LV
+64,Ruth,Gibson,Female,YE
+65,John,Reynolds,Male,CN
+66,Nancy,Berry,Female,PH
+67,Kevin,Kelly,Male,PL
+68,Sean,Williamson,Male,PH
+69,Jeremy,Rogers,Male,CN
+70,Emily,Carroll,Female,ME
+71,Antonio,Torres,Male,RU
+72,Willie,Barnes,Male,ID
+73,Margaret,Lewis,Female,PL
+74,Douglas,Dunn,Male,IL
+75,Lois,Cruz,Female,LY
+76,Lori,Reynolds,Female,CG
+77,Debra,Ray,Female,CZ
+78,Brandon,Garza,Male,MN
+79,Norma,Smith,Female,MX
+80,Jennifer,Murray,Female,PT
+81,Howard,Chapman,Male,CN
+82,Diane,Cox,Female,IE
+83,Victor,Martinez,Male,ID
+84,Sara,Olson,Female,CN
+85,Joyce,Snyder,Female,CA
+86,Bruce,Price,Male,KI
+87,Ryan,Lane,Male,IR
+88,Jean,Richards,Female,RU
+89,Nicholas,Carpenter,Male,CI
+90,Richard,Burke,Male,AR
+91,Harry,Young,Male,GT
+92,Walter,Boyd,Male,PH
+93,Roy,Cox,Male,BR
+94,Judy,Myers,Female,CN
+95,Jason,Alexander,Male,RU
+96,Henry,James,Male,PT
+97,George,Hawkins,Male,IR
+98,Irene,Chavez,Female,FR
+99,Willie,Alvarez,Male,ID
+100,Evelyn,Kennedy,Female,HT`

--- a/mock/csv_mock.go
+++ b/mock/csv_mock.go
@@ -1,0 +1,96 @@
+package mock
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+	ds "github.com/grafana/sqlds/v2"
+	_ "github.com/mithrandie/csvq-driver"
+)
+
+// SQLCSVMock connects to a local folder with csv files
+type SQLCSVMock struct {
+	folder string
+}
+
+func (h *SQLCSVMock) Settings(config backend.DataSourceInstanceSettings) ds.DriverSettings {
+	return ds.DriverSettings{
+		FillMode: &data.FillMissing{
+			Mode: data.FillModeNull,
+		},
+		Timeout: time.Second * time.Duration(30),
+	}
+}
+
+// Connect opens a sql.DB connection using datasource settings
+func (h *SQLCSVMock) Connect(config backend.DataSourceInstanceSettings, msg json.RawMessage) (*sql.DB, error) {
+	backend.Logger.Debug("connecting to mock data")
+	folder := h.folder
+	if folder == "" {
+		folder = MockDataFolder
+	}
+	if !strings.HasPrefix(folder, "/") {
+		folder = "/" + folder
+	}
+	err := CreateMockTable("users", folder)
+	if err != nil {
+		backend.Logger.Error("failed creating mock data: " + err.Error())
+		return nil, err
+	}
+	ex, err := os.Executable()
+	if err != nil {
+		backend.Logger.Error("failed accessing Mock path: " + err.Error())
+	}
+	exPath := filepath.Dir(ex)
+	db, err := sql.Open("csvq", exPath+folder)
+	if err != nil {
+		backend.Logger.Error("failed opening Mock sql: " + err.Error())
+		return nil, err
+	}
+	err = db.Ping()
+	if err != nil {
+		backend.Logger.Error("failed connecting to Mock: " + err.Error())
+	}
+
+	timeout := time.Duration(1999)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout*time.Second)
+	defer cancel()
+
+	chErr := make(chan error, 1)
+	go func() {
+		err = db.PingContext(ctx)
+		duration := time.Second * 60
+		time.Sleep(duration)
+		chErr <- err
+	}()
+
+	select {
+	case err := <-chErr:
+		if err != nil {
+			// log.DefaultLogger.Error(err.Error())
+			return db, err
+		}
+	case <-time.After(timeout * time.Second):
+		return db, errors.New("connection timed out")
+	}
+	return db, nil
+}
+
+// Converters defines list of string convertors
+func (h *SQLCSVMock) Converters() []sqlutil.Converter {
+	return []sqlutil.Converter{}
+}
+
+// Macros returns list of macro functions convert the macros of raw query
+func (h *SQLCSVMock) Macros() ds.Macros {
+	return ds.Macros{}
+}

--- a/mock/mock_driver.go
+++ b/mock/mock_driver.go
@@ -1,0 +1,35 @@
+package mock
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"sync"
+)
+
+var pool *mockDriver
+
+func init() {
+	pool = &mockDriver{
+		conns: make(map[string]*sqlmock),
+	}
+	sql.Register("sqlmock", pool)
+}
+
+type mockDriver struct {
+	sync.Mutex
+	counter int
+	conns   map[string]*sqlmock
+}
+
+func (d *mockDriver) Open(dsn string) (driver.Conn, error) {
+	if len(d.conns) == 0 {
+		mock := &sqlmock{
+			drv:   d,
+			sleep: 10,
+		}
+		d.conns = map[string]*sqlmock{
+			dsn: mock,
+		}
+	}
+	return d.conns[dsn], nil
+}

--- a/mock/sqlmock.go
+++ b/mock/sqlmock.go
@@ -1,0 +1,70 @@
+package mock
+
+import (
+	"context"
+	"database/sql/driver"
+	"time"
+)
+
+type sqlmock struct {
+	drv   *mockDriver
+	sleep int
+}
+
+// Begin meets http://golang.org/pkg/database/sql/driver/#Conn interface
+func (c *sqlmock) Begin() (driver.Tx, error) {
+	return c, nil
+}
+
+// Prepare meets http://golang.org/pkg/database/sql/driver/#Conn interface
+func (c *sqlmock) Prepare(query string) (driver.Stmt, error) {
+	return &statement{c, query}, nil
+}
+
+// Prepare meets http://golang.org/pkg/database/sql/driver/#Conn interface
+func (c *sqlmock) Commit() error {
+	return nil
+}
+
+// Prepare meets http://golang.org/pkg/database/sql/driver/#Conn interface
+func (c *sqlmock) Rollback() error {
+	return nil
+}
+
+// Prepare meets http://golang.org/pkg/database/sql/driver/#Conn interface
+func (c *sqlmock) Close() error {
+	return nil
+}
+
+func (c *sqlmock) Ping(ctx context.Context) error {
+	// so we can test timeout retries
+	if c.sleep > 0 {
+		v := c.sleep
+		next := float64(v) * .5
+		c.sleep = int(next)
+		time.Sleep(time.Duration(v) * time.Second)
+	}
+	return nil
+}
+
+// statement
+type statement struct {
+	conn  *sqlmock
+	query string
+}
+
+func (stmt *statement) Exec(args []driver.Value) (driver.Result, error) {
+	return nil, nil
+}
+
+func (stmt *statement) Query(args []driver.Value) (driver.Rows, error) {
+	return nil, nil
+}
+
+func (stmt *statement) Close() error {
+	return nil
+}
+
+func (stmt *statement) NumInput() int {
+	return -1
+}


### PR DESCRIPTION
- move mocks to mock folder
- the sqlmock is the start of a sql driver mock ( this will evolve )
- this allows us to have a driver that we can mock any way we want
- currently allows testing Ping and simulating a timeout scenario