### PR TITLE
retries, ping timeout, sql mock handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .vscode
 .idea/
 *.iml
+
+mock-data

--- a/csv_mock.go
+++ b/csv_mock.go
@@ -1,4 +1,4 @@
-package mock
+package sqlds
 
 import (
 	"context"
@@ -13,7 +13,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
-	ds "github.com/grafana/sqlds/v2"
 	_ "github.com/mithrandie/csvq-driver"
 )
 
@@ -22,8 +21,8 @@ type SQLCSVMock struct {
 	folder string
 }
 
-func (h *SQLCSVMock) Settings(config backend.DataSourceInstanceSettings) ds.DriverSettings {
-	return ds.DriverSettings{
+func (h *SQLCSVMock) Settings(config backend.DataSourceInstanceSettings) DriverSettings {
+	return DriverSettings{
 		FillMode: &data.FillMissing{
 			Mode: data.FillModeNull,
 		},
@@ -91,6 +90,6 @@ func (h *SQLCSVMock) Converters() []sqlutil.Converter {
 }
 
 // Macros returns list of macro functions convert the macros of raw query
-func (h *SQLCSVMock) Macros() ds.Macros {
-	return ds.Macros{}
+func (h *SQLCSVMock) Macros() Macros {
+	return Macros{}
 }

--- a/datasource.go
+++ b/datasource.go
@@ -265,6 +265,11 @@ func (ds *SQLDatasource) CheckHealth(ctx context.Context, req *backend.CheckHeal
 				Message: err.Error(),
 			}, nil
 		}
+
+		return &backend.CheckHealthResult{
+			Status:  backend.HealthStatusOk,
+			Message: "Data source is working",
+		}, nil
 	}
 
 	var err error

--- a/datasource.go
+++ b/datasource.go
@@ -270,8 +270,8 @@ func (ds *SQLDatasource) CheckHealth(ctx context.Context, req *backend.CheckHeal
 	var err error
 	for i := 0; i < ds.driverSettings.Retries; i++ {
 		err = ds.ping(dbConn)
-		if err != nil {
-			continue
+		if err == nil {
+			break
 		}
 	}
 

--- a/driver.go
+++ b/driver.go
@@ -14,6 +14,7 @@ import (
 type DriverSettings struct {
 	Timeout  time.Duration
 	FillMode *data.FillMissing
+	Retries  int
 }
 
 // Driver is a simple interface that defines how to connect to a backend SQL datasource

--- a/mock/csv/csv_data.go
+++ b/mock/csv/csv_data.go
@@ -1,4 +1,4 @@
-package mock
+package csv
 
 import (
 	"errors"

--- a/mock/csv/csv_mock.go
+++ b/mock/csv/csv_mock.go
@@ -1,4 +1,4 @@
-package sqlds
+package csv
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+	"github.com/grafana/sqlds/v2"
 	_ "github.com/mithrandie/csvq-driver"
 )
 
@@ -21,8 +22,8 @@ type SQLCSVMock struct {
 	folder string
 }
 
-func (h *SQLCSVMock) Settings(config backend.DataSourceInstanceSettings) DriverSettings {
-	return DriverSettings{
+func (h *SQLCSVMock) Settings(config backend.DataSourceInstanceSettings) sqlds.DriverSettings {
+	return sqlds.DriverSettings{
 		FillMode: &data.FillMissing{
 			Mode: data.FillModeNull,
 		},
@@ -90,6 +91,6 @@ func (h *SQLCSVMock) Converters() []sqlutil.Converter {
 }
 
 // Macros returns list of macro functions convert the macros of raw query
-func (h *SQLCSVMock) Macros() Macros {
-	return Macros{}
+func (h *SQLCSVMock) Macros() sqlds.Macros {
+	return sqlds.Macros{}
 }

--- a/mock/mock_driver.go
+++ b/mock/mock_driver.go
@@ -1,35 +1,52 @@
 package mock
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/json"
+	"errors"
 	"sync"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
 var pool *mockDriver
 
-func init() {
+func RegisterDriver(name string, handler DBHandler) *mockDriver {
 	pool = &mockDriver{
-		conns: make(map[string]*sqlmock),
+		conns:   make(map[string]*sqlmock),
+		handler: handler,
 	}
-	sql.Register("sqlmock", pool)
+	sql.Register(name, pool)
+	return pool
+}
+
+type DBHandler interface {
+	Ping(ctx context.Context) error
+	Query(args []driver.Value) (driver.Rows, error)
+	Columns() []string
+	Next(dest []driver.Value) error
 }
 
 type mockDriver struct {
 	sync.Mutex
-	counter int
 	conns   map[string]*sqlmock
+	handler DBHandler
 }
 
 func (d *mockDriver) Open(dsn string) (driver.Conn, error) {
 	if len(d.conns) == 0 {
 		mock := &sqlmock{
-			drv:   d,
-			sleep: 10,
+			drv: d,
 		}
 		d.conns = map[string]*sqlmock{
 			dsn: mock,
 		}
 	}
 	return d.conns[dsn], nil
+}
+
+func (d *mockDriver) Connect(backend.DataSourceInstanceSettings, json.RawMessage) (db *sql.DB, err error) {
+	return nil, errors.New("context deadline exceeded")
 }


### PR DESCRIPTION
* support retries - for situations where the db is temporarily unavailable
* use timeout setting when pinging - there is a timeout setting but ping didn't use it
* sql mock driver registry
  * allow providing a handler to handle ping, results - provides more control when mocking a driver