### PR TITLE
Fix parsing macros in complex queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/grafana/sqlds/v2
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-sql-driver/mysql v1.4.0
 	github.com/google/go-cmp v0.5.7
-	github.com/grafana/grafana-plugin-sdk-go v0.140.0
+	github.com/grafana/grafana-plugin-sdk-go v0.144.0
 	github.com/mithrandie/csvq-driver v1.6.8
 	github.com/stretchr/testify v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/grafana/grafana-plugin-sdk-go v0.140.0 h1:cxU8M99Z/V4FJNyseJrR8x509fSttJAoV+GWVL6ZdRY=
-github.com/grafana/grafana-plugin-sdk-go v0.140.0/go.mod h1:srvRQ+de4C5h7FqA5lSFUkFCs5pJolWT+PGV2AyBOFk=
+github.com/grafana/grafana-plugin-sdk-go v0.144.0 h1:NsuK9AKWeWBbuNREsF4hrLA3TnYPPpDJTqcPqm288aw=
+github.com/grafana/grafana-plugin-sdk-go v0.144.0/go.mod h1:dFof/7GenWBFTmrfcPRCpLau7tgIED0ykzupWAlB0o0=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
@@ -201,7 +201,6 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/magefile/mage v1.13.0 h1:XtLJl8bcCM7EFoO8FyH8XK3t7G5hQAeK+i4tq+veT9M=
 github.com/mattetti/filebuffer v1.0.1 h1:gG7pyfnSIZCxdoKq+cPa8T0hhYtD9NxCdI4D7PTjRLM=
 github.com/mattetti/filebuffer v1.0.1/go.mod h1:YdMURNDOttIiruleeVr6f56OrMc+MydEnTcXwtkxNVs=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=

--- a/macros.go
+++ b/macros.go
@@ -156,13 +156,15 @@ func getMacroMatches(input string, name string) ([][]string, error) {
 	for matchedIndex := 0; matchedIndex < len(matched); matchedIndex++ {
 		var macroEnd = 0
 		var argStart = 0
+		// quick exit from the loop, when we encounter a closing bracket before an opening one (ie "($__macro)", where we can skip the closing one from the result)
+		var forceBreak = false
 		macroStart := matched[matchedIndex][0]
 		inputCopy := input[macroStart:]
 		cache := make([]rune, 0)
 
 		// find the opening and closing arguments brackets
 		for idx, r := range inputCopy {
-			if len(cache) == 0 && macroEnd > 0 {
+			if len(cache) == 0 && macroEnd > 0 || forceBreak {
 				break
 			}
 			switch r {
@@ -174,6 +176,8 @@ func getMacroMatches(input string, name string) ([][]string, error) {
 			case ')':
 				l := len(cache)
 				if l == 0 {
+					macroEnd = 0
+					forceBreak = true
 					break
 				}
 				cache = cache[:l-1]

--- a/macros_test.go
+++ b/macros_test.go
@@ -69,6 +69,8 @@ func TestInterpolate(t *testing.T) {
 		{input: "select * from foo where $__timeFrom(cast(sth as timestamp))", output: "select * from foo where cast(sth as timestamp) >= '0001-01-01T00:00:00Z'", name: "default timeFrom macro"},
 		{input: "select * from foo where $__timeGroup(time,minute)", output: "select * from foo where grouped!", name: "overriden timeGroup macro"},
 		{input: "select $__column from $__table", output: "select my_col from my_table", name: "table and column macros"},
+		{input: "select * from table where ( datetime >= $__foo() ) AND ( datetime <= $__foo() ) limit 100", output: "select * from table where ( datetime >= bar ) AND ( datetime <= bar ) limit 100", name: "macro functions inside more complex clauses"},
+		{input: "select * from table where ( datetime >= $__foo ) AND ( datetime <= $__foo ) limit 100", output: "select * from table where ( datetime >= bar ) AND ( datetime <= bar ) limit 100", name: "macros inside more complex clauses"},
 	}
 	for i, tc := range tests {
 		driver := MockDB{}


### PR DESCRIPTION
- update go to 1.19
- update plugin sdk

This fixes the case, where user would have a query like `select * from foo default where ( date >= $__fromTime ) and ( date <= $__toTime ) limit 100` and parser would incorrectly only properly recognize the first macro (originally reported in clickhouse https://github.com/grafana/clickhouse-datasource/issues/236) . Added additional test cases to cover that.