### PR TITLE
add format option for trace

### DIFF
--- a/query.go
+++ b/query.go
@@ -23,6 +23,8 @@ const (
 	FormatOptionTable
 	// FormatOptionLogs sets the preferred visualization to logs
 	FormatOptionLogs
+	// FormatOptionsTrace sets the preferred visualization to trace
+	FormatOptionTrace
 )
 
 // Query is the model that represents the query that users submit from the panel / queryeditor.
@@ -155,6 +157,11 @@ func getFrames(rows *sql.Rows, limit int64, converters []sqlutil.Converter, fill
 
 	if query.Format == FormatOptionLogs {
 		frame.Meta.PreferredVisualization = data.VisTypeLogs
+		return data.Frames{frame}, nil
+	}
+
+	if query.Format == FormatOptionTrace {
+		frame.Meta.PreferredVisualization = data.VisTypeTrace
 		return data.Frames{frame}, nil
 	}
 


### PR DESCRIPTION
Dup of #81 on an account where the CLA signing works.

This PR just adds another enum for queries to return preferredVisualization: "trace"

Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/grafana/sqlds/pull/84).
* __->__ #84

add format option for trace

