### PR TITLE
QueryMutator interface for driver

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -178,6 +178,10 @@ func (ds *SQLDatasource) getDBConnectionFromQuery(q *Query, datasourceUID string
 
 // handleQuery will call query, and attempt to reconnect if the query failed
 func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery, datasourceUID string) (data.Frames, error) {
+	if queryMutator, ok := ds.c.(QueryMutator); ok {
+		ctx, req = queryMutator.MutateQuery(ctx, req)
+	}
+
 	// Convert the backend.DataQuery into a Query object
 	q, err := GetQuery(req)
 	if err != nil {

--- a/driver.go
+++ b/driver.go
@@ -37,3 +37,9 @@ type Connection interface {
 	PingContext(ctx context.Context) error
 	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 }
+
+// QueryMutator is an additional interface that could be implemented by driver.
+// This adds ability to the driver it can mutate query before run.
+type QueryMutator interface {
+	MutateQuery(ctx context.Context, req backend.DataQuery) (context.Context, backend.DataQuery)
+}


### PR DESCRIPTION
QueryMutator is an additional interface that could be implemented by driver.
This adds ability to the driver it can mutate query before run.

Context explained in:
https://github.com/grafana/clickhouse-datasource/issues/295
https://github.com/grafana/clickhouse-datasource/pull/314