### PR TITLE
Allow capability for implementing datasources to set query args

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -257,7 +257,7 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 				if ds.driverSettings.Pause > 0 {
 					time.Sleep(time.Duration(ds.driverSettings.Pause * int(time.Second)))
 				}
-				res, err = QueryDB(ctx, db, ds.c.Converters(), fillMode, q)
+				res, err = QueryDB(ctx, db, ds.c.Converters(), fillMode, q, args...)
 				if err == nil {
 					return res, err
 				}
@@ -278,7 +278,7 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 				continue
 			}
 
-			res, err = QueryDB(ctx, db, ds.c.Converters(), fillMode, q)
+			res, err = QueryDB(ctx, db, ds.c.Converters(), fillMode, q, args...)
 			if err == nil {
 				return res, err
 			}

--- a/datasource.go
+++ b/datasource.go
@@ -224,11 +224,16 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 		ctx = tctx
 	}
 
+	var args []interface{}
+	if argSetter, ok := ds.c.(QueryArgSetter); ok {
+		args = argSetter.SetQueryArgs(ctx, headers)
+	}
+
 	// FIXES:
 	//  * Some datasources (snowflake) expire connections or have an authentication token that expires if not used in 1 or 4 hours.
 	//    Because the datasource driver does not include an option for permanent connections, we retry the connection
 	//    if the query fails. NOTE: this does not include some errors like "ErrNoRows"
-	res, err := QueryDB(ctx, dbConn.db, ds.c.Converters(), fillMode, q)
+	res, err := QueryDB(ctx, dbConn.db, ds.c.Converters(), fillMode, q, args...)
 	if err == nil {
 		return res, nil
 	}

--- a/driver.go
+++ b/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"net/http"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -45,6 +46,12 @@ type Connection interface {
 // This adds ability to the driver it can mutate query before run.
 type QueryMutator interface {
 	MutateQuery(ctx context.Context, req backend.DataQuery) (context.Context, backend.DataQuery)
+}
+
+// QueryArgSetter is an additional interface that could be implemented by driver.
+// This adds the ability to the driver to optionally set query args that are then sent down to the database.
+type QueryArgSetter interface {
+	SetQueryArgs(ctx context.Context, headers http.Header) []interface{}
 }
 
 // ResponseMutator is an additional interface that could be implemented by driver.


### PR DESCRIPTION
Similar to the optional interfaces that allow datasources to mutate queries and responses, this implements the ability for datasources to set query args in the call `QueryDB`. Right now, this interface's method `SetQueryArgs` takes the HTTP headers (you could use this to set the username for example), but it could easily be expanded to allow for other parameters.