### PR TITLE
Update usage instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,14 @@ The `sqlds` package is intended to remove the repetition of these datasources an
 **Usage**
 
 ```go
-ds := sqlds.NewDatasource(&myDatasource{})
-if err := datasource.Manage("my-datasource", ds.NewDatasource, datasource.ManageOpts{}); err != nil {
+if err := datasource.Manage("my-datasource", datasourceFactory, datasource.ManageOpts{}); err != nil {
   log.DefaultLogger.Error(err.Error())
   os.Exit(1)
+}
+
+func datasourceFactory(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+  ds := sqlds.NewDatasource(&myDatasource{})
+  return ds.NewDatasource(s)
 }
 ```
 


### PR DESCRIPTION
Rather than sharing a single `sqlds` instance for every underlying instance managed by the SDK, this updated pattern ensures each plugin instance is independent from one another. Please see [here](https://docs.google.com/document/d/1Lm76T1U0TE4tIoA274l3aFUqW3medn2rzZzBplQQgT4) for more context.