### PR TITLE
Add a multi timeseries return format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.21.1
 require (
 	github.com/go-sql-driver/mysql v1.4.0
 	github.com/google/go-cmp v0.5.9
+	github.com/grafana/dataplane/sdata v0.0.7
 	github.com/grafana/grafana-plugin-sdk-go v0.188.3
 	github.com/mithrandie/csvq-driver v1.6.8
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e h1:JKmoR8x90Iww1
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/grafana/dataplane/sdata v0.0.7 h1:CImITypIyS1jxijCR6xqKx71JnYAxcwpH9ChK0gH164=
+github.com/grafana/dataplane/sdata v0.0.7/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
 github.com/grafana/grafana-plugin-sdk-go v0.188.3 h1:91wrmnS6zXs4FhriVesZujkmjrwY1xhsusL30CtLkEE=
 github.com/grafana/grafana-plugin-sdk-go v0.188.3/go.mod h1:nctofuR6fyhx3Stbnh5ha6setroeqqBgO0Rj9s4t86o=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=


### PR DESCRIPTION
Add support for returning data in the multi format for timeseries. The plan has shifted a bit: instead of return the multi format for timeseries instead of wide (what's described in the issue) I'm instead adding a multi return format for users who want a timeseries format for data with a lot of labels that don't have points for every time. This avoids creating a massive change for other users of the library.

Part of #96 