### PR TITLE
capture duration and label with error source

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -266,8 +266,8 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 					time.Sleep(time.Duration(ds.driverSettings.Pause * int(time.Second)))
 				}
 
-				sqlQuery := NewQuery(db, dbConn.settings, ds.c.Converters(), fillMode)
-				res, err = sqlQuery.Run(ctx, q, args...)
+				dbQuery := NewQuery(db, dbConn.settings, ds.c.Converters(), fillMode)
+				res, err = dbQuery.Run(ctx, q, args...)
 				if err == nil {
 					return res, err
 				}
@@ -288,8 +288,8 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 				continue
 			}
 
-			sqlQuery := NewQuery(db, dbConn.settings, ds.c.Converters(), fillMode)
-			res, err = sqlQuery.Run(ctx, q, args...)
+			dbQuery := NewQuery(db, dbConn.settings, ds.c.Converters(), fillMode)
+			res, err = dbQuery.Run(ctx, q, args...)
 			if err == nil {
 				return res, err
 			}

--- a/datasource.go
+++ b/datasource.go
@@ -6,11 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
@@ -239,7 +240,8 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 	//  * Some datasources (snowflake) expire connections or have an authentication token that expires if not used in 1 or 4 hours.
 	//    Because the datasource driver does not include an option for permanent connections, we retry the connection
 	//    if the query fails. NOTE: this does not include some errors like "ErrNoRows"
-	res, err := QueryDB(ctx, dbConn.db, ds.c.Converters(), fillMode, q, args...)
+	sqlQuery := NewQuery(dbConn.db, dbConn.settings, ds.c.Converters(), fillMode)
+	res, err := sqlQuery.Run(ctx, q, args...)
 	if err == nil {
 		return res, nil
 	}
@@ -263,7 +265,9 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 				if ds.driverSettings.Pause > 0 {
 					time.Sleep(time.Duration(ds.driverSettings.Pause * int(time.Second)))
 				}
-				res, err = QueryDB(ctx, db, ds.c.Converters(), fillMode, q, args...)
+
+				sqlQuery := NewQuery(db, dbConn.settings, ds.c.Converters(), fillMode)
+				res, err = sqlQuery.Run(ctx, q, args...)
 				if err == nil {
 					return res, err
 				}
@@ -284,7 +288,8 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 				continue
 			}
 
-			res, err = QueryDB(ctx, db, ds.c.Converters(), fillMode, q, args...)
+			sqlQuery := NewQuery(db, dbConn.settings, ds.c.Converters(), fillMode)
+			res, err = sqlQuery.Run(ctx, q, args...)
 			if err == nil {
 				return res, err
 			}

--- a/datasource.go
+++ b/datasource.go
@@ -240,8 +240,8 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 	//  * Some datasources (snowflake) expire connections or have an authentication token that expires if not used in 1 or 4 hours.
 	//    Because the datasource driver does not include an option for permanent connections, we retry the connection
 	//    if the query fails. NOTE: this does not include some errors like "ErrNoRows"
-	sqlQuery := NewQuery(dbConn.db, dbConn.settings, ds.c.Converters(), fillMode)
-	res, err := sqlQuery.Run(ctx, q, args...)
+	dbQuery := NewQuery(dbConn.db, dbConn.settings, ds.c.Converters(), fillMode)
+	res, err := dbQuery.Run(ctx, q, args...)
 	if err == nil {
 		return res, nil
 	}

--- a/query.go
+++ b/query.go
@@ -248,8 +248,8 @@ func applyHeaders(query *Query, headers http.Header) *Query {
 }
 
 // sanitizeLabelName removes all invalid chars from the label name.
-// If the label name is empty or contains only invalid chars, it
-// will return an error.
+// If the label name is empty or contains only invalid chars, it will return false indicating it was not sanitized.
+// copied from https://github.com/grafana/grafana/blob/main/pkg/infra/metrics/metricutil/utils.go#L14
 func sanitizeLabelName(name string) (string, bool) {
 	if len(name) == 0 {
 		backend.Logger.Warn(fmt.Sprintf("label name cannot be empty: %s", name))

--- a/query.go
+++ b/query.go
@@ -83,7 +83,6 @@ func NewQuery(db Connection, settings backend.DataSourceInstanceSettings, conver
 
 // Run sends the query to the connection and converts the rows to a dataframe.
 func (q *DBQuery) Run(ctx context.Context, query *Query, args ...interface{}) (data.Frames, error) {
-	// Query the rows from the database
 	start := time.Now()
 	var errWithSource error
 

--- a/query_integration_test.go
+++ b/query_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -75,7 +76,12 @@ func TestQuery_MySQL(t *testing.T) {
 			RawSQL: "SELECT SLEEP(5)",
 		}
 
-		_, err := QueryDB(ctx, db, []sqlutil.Converter{}, nil, q)
+		settings := backend.DataSourceInstanceSettings{
+			Name: "foo",
+		}
+
+		sqlQuery := NewQuery(db, settings, []sqlutil.Converter{}, nil)
+		_, err := sqlQuery.Run(ctx, q)
 		if err == nil {
 			t.Fatal("expected an error but received none")
 		}

--- a/query_test.go
+++ b/query_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -162,4 +163,28 @@ func TestFixFrameForLongToMulti(t *testing.T) {
 		err := fixFrameForLongToMulti(frame)
 		require.Equal(t, err, fmt.Errorf("can not convert to wide series, input is missing a time field"))
 	})
+}
+
+func TestLabelNameSanitization(t *testing.T) {
+	testcases := []struct {
+		input    string
+		expected string
+		err      bool
+	}{
+		{input: "job", expected: "job"},
+		{input: "job._loal['", expected: "job_loal"},
+		{input: "", expected: "", err: true},
+		{input: ";;;", expected: "", err: true},
+		{input: "Data source", expected: "Data_source"},
+	}
+
+	for _, tc := range testcases {
+		got, ok := sanitizeLabelName(tc.input)
+		if tc.err {
+			assert.Equal(t, false, ok)
+		} else {
+			assert.Equal(t, true, ok)
+			assert.Equal(t, tc.expected, got)
+		}
+	}
 }

--- a/query_test.go
+++ b/query_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 	"github.com/stretchr/testify/require"
@@ -78,7 +79,12 @@ func TestQuery_Timeout(t *testing.T) {
 
 		defer conn.Close()
 
-		_, err := QueryDB(ctx, conn, []sqlutil.Converter{}, nil, &Query{})
+		settings := backend.DataSourceInstanceSettings{
+			Name: "foo",
+		}
+
+		sqlQuery := NewQuery(conn, settings, []sqlutil.Converter{}, nil)
+		_, err := sqlQuery.Run(ctx, &Query{})
 
 		if !errors.Is(err, context.Canceled) {
 			t.Fatal("expected error to be context.Canceled, received", err)
@@ -100,7 +106,12 @@ func TestQuery_Timeout(t *testing.T) {
 
 		defer conn.Close()
 
-		_, err := QueryDB(ctx, conn, []sqlutil.Converter{}, nil, &Query{})
+		settings := backend.DataSourceInstanceSettings{
+			Name: "foo",
+		}
+
+		sqlQuery := NewQuery(conn, settings, []sqlutil.Converter{}, nil)
+		_, err := sqlQuery.Run(ctx, &Query{})
 
 		if !errors.Is(err, ErrorQuery) {
 			t.Fatal("expected function to complete, received error: ", err)


### PR DESCRIPTION
* capture duration as a prometheus metric
* add error source label
* refactor a bit.  the QueryDB function had a lot of params.  try to reduce the arity