### PR TITLE
Return ExecutedQueryString even when an error is returned

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -291,7 +291,7 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 		}
 	}
 
-	return nil, err
+	return res, err
 }
 
 func (ds *SQLDatasource) dbReconnect(ctx context.Context, dbConn dbConnection, q *Query, cacheKey string) (*sql.DB, error) {


### PR DESCRIPTION
currently, when there's an error (for example an error in the sql query), we do not get back the executed-query-string into grafana's query inspector:

- in `QueryDB` we do construct a dataframe with the required metadata: https://github.com/grafana/sqlds/blob/3c409475badfb0bad9e76f547fa01a676d351e0a/query.go#L64
- but in `handleQuery`, when `QueryDB` ends with an error, we do not return the "returned" dataframe in the general case: https://github.com/grafana/sqlds/blob/3c409475badfb0bad9e76f547fa01a676d351e0a/datasource.go#L294

this PR returns the result, but i'm not sure if this is the best approach. could there be some leak of info with this that we want to avoid? WDYT?

