### PR TITLE
test: fix Next() method

### DIFF
--- a/test/driver.go
+++ b/test/driver.go
@@ -104,11 +104,11 @@ func (s *SqlHandler) Next(dest []driver.Value) error {
 		return io.EOF
 	}
 
+	row := s.Data.Rows[s.row]
 	s.row++
-	for _, row := range s.Data.Rows {
-		for i, col := range row {
-			dest[i] = col
-		}
+
+	for i, col := range row {
+		dest[i] = col
 	}
 	return nil
 }


### PR DESCRIPTION
in the current codebase, in the test-driver, when `Next()` is called, it goes through every row, and copies the row to `dest`.. 

for example, let's say these are the rows:
- north, 23
- east, 33
- south, 41

`Next()` will first copy `north, 23` into `dest`, then will overwrite it with `east, 33`, then will overwrite it with `south, 41`.
so when it all ends, the dataframe will look like this:
`fields: [ [south, south, south], [41, 41, 41] ]`

the PR adjusts the code so it only copies the row at the right index.
