### PR TITLE
adjusted handling of zero-rows results

### DIFF
--- a/dataframe_test.go
+++ b/dataframe_test.go
@@ -40,7 +40,7 @@ func TestNoRowsFrame(t *testing.T) {
 				},
 				Rows: [][]any{},
 			},
-			expectedFieldCount: 0,
+			expectedFieldCount: 2,
 		},
 		{
 			name:   "empty wide",
@@ -135,7 +135,7 @@ func TestNoRowsFrame(t *testing.T) {
 				},
 				Rows: [][]any{},
 			},
-			expectedFieldCount: 0,
+			expectedFieldCount: 2,
 		},
 		{
 			name:   "trace",
@@ -151,7 +151,7 @@ func TestNoRowsFrame(t *testing.T) {
 				},
 				Rows: [][]any{},
 			},
-			expectedFieldCount: 0,
+			expectedFieldCount: 1,
 		},
 	}
 


### PR DESCRIPTION
( fixes https://github.com/grafana/sqlds/issues/118 )

when the `multi` format was added, we unintentionally changed how we handle zero-rows sql-responses.. previously, for all-formats-except-timeseries, we returned the real dataframe-fields (the fields had zero items in them).

this PR adjusts the behavior to be the same as it was before. (i literally took the `dataframe_test.go` file, and ran it on a git-checkout of the old-version, and wrote down the results there).

NOTE: there was no format=multi in the "before" situation, so for that case, i kept the current behavior (no dataframe-fields when zero-rows).