### PR TITLE
slo - capture query and health duration - label with error source

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -42,8 +42,6 @@ func NewConnector(ctx context.Context, driver Driver, settings backend.DataSourc
 }
 
 func (c *Connector) Connect(ctx context.Context, headers http.Header) (*dbConnection, error) {
-	start := time.Now()
-
 	key := defaultKey(c.UID)
 	dbConn, ok := c.getDBConnection(key)
 	if !ok {
@@ -56,11 +54,6 @@ func (c *Connector) Connect(ctx context.Context, headers http.Header) (*dbConnec
 	}
 
 	err := c.connectWithRetries(ctx, dbConn, key, headers)
-	if err != nil {
-		healthExternalDuration.WithLabelValues(dbConn.settings.Name, dbConn.settings.Type, string(ErrorSource(err))).Observe(time.Since(start).Seconds())
-	} else {
-		healthExternalDuration.WithLabelValues(dbConn.settings.Name, dbConn.settings.Type, "none").Observe(time.Since(start).Seconds())
-	}
 	return &dbConn, err
 }
 

--- a/connector.go
+++ b/connector.go
@@ -134,13 +134,13 @@ func (ds *Connector) storeDBConnection(key string, dbConn dbConnection) {
 	ds.connections.Store(key, dbConn)
 }
 
-func (c *Connector) GetConnectionFromQuery(ctx context.Context, q *Query, datasourceUID string) (string, dbConnection, error) {
+func (c *Connector) GetConnectionFromQuery(ctx context.Context, q *Query) (string, dbConnection, error) {
 	if !c.enableMultipleConnections && !c.driverSettings.ForwardHeaders && len(q.ConnectionArgs) > 0 {
 		return "", dbConnection{}, MissingMultipleConnectionsConfig
 	}
 	// The database connection may vary depending on query arguments
 	// The raw arguments are used as key to store the db connection in memory so they can be reused
-	key := defaultKey(datasourceUID)
+	key := defaultKey(c.UID)
 	dbConn, ok := c.getDBConnection(key)
 	if !ok {
 		return "", dbConnection{}, MissingDBConnection
@@ -149,7 +149,7 @@ func (c *Connector) GetConnectionFromQuery(ctx context.Context, q *Query, dataso
 		return key, dbConn, nil
 	}
 
-	key = keyWithConnectionArgs(datasourceUID, q.ConnectionArgs)
+	key = keyWithConnectionArgs(c.UID, q.ConnectionArgs)
 	if cachedConn, ok := c.getDBConnection(key); ok {
 		return key, cachedConn, nil
 	}

--- a/datasource.go
+++ b/datasource.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -46,11 +45,7 @@ type dbConnection struct {
 
 type SQLDatasource struct {
 	Completable
-
-	dbConnections  sync.Map
-	c              Driver
-	driverSettings DriverSettings
-
+	connector *Connector
 	backend.CallResourceHandler
 	CustomRoutes map[string]func(http.ResponseWriter, *http.Request)
 	// Enabling multiple connections may cause that concurrent connection limits
@@ -59,37 +54,14 @@ type SQLDatasource struct {
 	EnableMultipleConnections bool
 }
 
-func (ds *SQLDatasource) getDBConnection(key string) (dbConnection, bool) {
-	conn, ok := ds.dbConnections.Load(key)
-	if !ok {
-		return dbConnection{}, false
-	}
-	return conn.(dbConnection), true
-}
-
-func (ds *SQLDatasource) storeDBConnection(key string, dbConn dbConnection) {
-	ds.dbConnections.Store(key, dbConn)
-}
-
-func getDatasourceUID(settings backend.DataSourceInstanceSettings) string {
-	datasourceUID := settings.UID
-	// Grafana < 8.0 won't include the UID yet
-	if datasourceUID == "" {
-		datasourceUID = fmt.Sprintf("%d", settings.ID)
-	}
-	return datasourceUID
-}
-
 // NewDatasource creates a new `SQLDatasource`.
 // It uses the provided settings argument to call the ds.Driver to connect to the SQL server
 func (ds *SQLDatasource) NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-	db, err := ds.c.Connect(ctx, settings, nil)
+	conn, err := NewConnector(ctx, ds.driver(), settings, ds.EnableMultipleConnections)
 	if err != nil {
 		return nil, DownstreamError(err)
 	}
-	key := defaultKey(getDatasourceUID(settings))
-	ds.storeDBConnection(key, dbConnection{db, settings})
-
+	ds.connector = conn
 	mux := http.NewServeMux()
 	err = ds.registerRoutes(mux)
 	if err != nil {
@@ -97,7 +69,6 @@ func (ds *SQLDatasource) NewDatasource(ctx context.Context, settings backend.Dat
 	}
 
 	ds.CallResourceHandler = httpadapter.New(mux)
-	ds.driverSettings = ds.c.Settings(ctx, settings)
 
 	return ds, nil
 }
@@ -105,7 +76,7 @@ func (ds *SQLDatasource) NewDatasource(ctx context.Context, settings backend.Dat
 // NewDatasource initializes the Datasource wrapper and instance manager
 func NewDatasource(c Driver) *SQLDatasource {
 	return &SQLDatasource{
-		c: c,
+		connector: &Connector{driver: c},
 	}
 }
 
@@ -128,9 +99,9 @@ func (ds *SQLDatasource) QueryData(ctx context.Context, req *backend.QueryDataRe
 	// Execute each query and store the results by query RefID
 	for _, q := range req.Queries {
 		go func(query backend.DataQuery) {
-			frames, err := ds.handleQuery(ctx, query, getDatasourceUID(*req.PluginContext.DataSourceInstanceSettings), headers)
+			frames, err := ds.handleQuery(ctx, query, req.PluginContext.DataSourceInstanceSettings.UID, headers)
 			if err == nil {
-				if responseMutator, ok := ds.c.(ResponseMutator); ok {
+				if responseMutator, ok := ds.driver().(ResponseMutator); ok {
 					frames, err = responseMutator.MutateResponse(ctx, frames)
 					if err != nil {
 						err = PluginError(err)
@@ -151,7 +122,7 @@ func (ds *SQLDatasource) QueryData(ctx context.Context, req *backend.QueryDataRe
 	wg.Wait()
 
 	errs := ds.errors(response)
-	if ds.driverSettings.Errors {
+	if ds.DriverSettings().Errors {
 		return response.Response(), errs
 	}
 
@@ -159,80 +130,49 @@ func (ds *SQLDatasource) QueryData(ctx context.Context, req *backend.QueryDataRe
 }
 
 func (ds *SQLDatasource) GetDBFromQuery(ctx context.Context, q *Query, datasourceUID string) (*sql.DB, error) {
-	_, dbConn, err := ds.getDBConnectionFromQuery(ctx, q, datasourceUID)
+	_, dbConn, err := ds.connector.GetConnectionFromQuery(ctx, q, datasourceUID)
 	return dbConn.db, err
-}
-
-func (ds *SQLDatasource) getDBConnectionFromQuery(ctx context.Context, q *Query, datasourceUID string) (string, dbConnection, error) {
-	if !ds.EnableMultipleConnections && !ds.driverSettings.ForwardHeaders && len(q.ConnectionArgs) > 0 {
-		return "", dbConnection{}, MissingMultipleConnectionsConfig
-	}
-	// The database connection may vary depending on query arguments
-	// The raw arguments are used as key to store the db connection in memory so they can be reused
-	key := defaultKey(datasourceUID)
-	dbConn, ok := ds.getDBConnection(key)
-	if !ok {
-		return "", dbConnection{}, MissingDBConnection
-	}
-	if !ds.EnableMultipleConnections || len(q.ConnectionArgs) == 0 {
-		return key, dbConn, nil
-	}
-
-	key = keyWithConnectionArgs(datasourceUID, q.ConnectionArgs)
-	if cachedConn, ok := ds.getDBConnection(key); ok {
-		return key, cachedConn, nil
-	}
-
-	db, err := ds.c.Connect(ctx, dbConn.settings, q.ConnectionArgs)
-	if err != nil {
-		return "", dbConnection{}, DownstreamError(err)
-	}
-	// Assign this connection in the cache
-	dbConn = dbConnection{db, dbConn.settings}
-	ds.storeDBConnection(key, dbConn)
-
-	return key, dbConn, nil
 }
 
 // handleQuery will call query, and attempt to reconnect if the query failed
 func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery, datasourceUID string, headers http.Header) (data.Frames, error) {
-	if queryMutator, ok := ds.c.(QueryMutator); ok {
+	if queryMutator, ok := ds.driver().(QueryMutator); ok {
 		ctx, req = queryMutator.MutateQuery(ctx, req)
 	}
 
 	// Convert the backend.DataQuery into a Query object
-	q, err := GetQuery(req, headers, ds.driverSettings.ForwardHeaders)
+	q, err := GetQuery(req, headers, ds.DriverSettings().ForwardHeaders)
 	if err != nil {
 		return nil, err
 	}
 
 	// Apply supported macros to the query
-	q.RawSQL, err = Interpolate(ds.c, q)
+	q.RawSQL, err = Interpolate(ds.driver(), q)
 	if err != nil {
 		return sqlutil.ErrorFrameFromQuery(q), fmt.Errorf("%s: %w", "Could not apply macros", err)
 	}
 
 	// Apply the default FillMode, overwritting it if the query specifies it
-	fillMode := ds.driverSettings.FillMode
+	fillMode := ds.DriverSettings().FillMode
 	if q.FillMissing != nil {
 		fillMode = q.FillMissing
 	}
 
 	// Retrieve the database connection
-	cacheKey, dbConn, err := ds.getDBConnectionFromQuery(ctx, q, datasourceUID)
+	cacheKey, dbConn, err := ds.connector.GetConnectionFromQuery(ctx, q, datasourceUID)
 	if err != nil {
 		return sqlutil.ErrorFrameFromQuery(q), err
 	}
 
-	if ds.driverSettings.Timeout != 0 {
-		tctx, cancel := context.WithTimeout(ctx, ds.driverSettings.Timeout)
+	if ds.DriverSettings().Timeout != 0 {
+		tctx, cancel := context.WithTimeout(ctx, ds.DriverSettings().Timeout)
 		defer cancel()
 
 		ctx = tctx
 	}
 
 	var args []interface{}
-	if argSetter, ok := ds.c.(QueryArgSetter); ok {
+	if argSetter, ok := ds.driver().(QueryArgSetter); ok {
 		args = argSetter.SetQueryArgs(ctx, headers)
 	}
 
@@ -240,7 +180,7 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 	//  * Some datasources (snowflake) expire connections or have an authentication token that expires if not used in 1 or 4 hours.
 	//    Because the datasource driver does not include an option for permanent connections, we retry the connection
 	//    if the query fails. NOTE: this does not include some errors like "ErrNoRows"
-	dbQuery := NewQuery(dbConn.db, dbConn.settings, ds.c.Converters(), fillMode)
+	dbQuery := NewQuery(dbConn.db, dbConn.settings, ds.driver().Converters(), fillMode)
 	res, err := dbQuery.Run(ctx, q, args...)
 	if err == nil {
 		return res, nil
@@ -254,24 +194,24 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 	// context deadline retry the query
 	if errors.Is(err, ErrorQuery) && !errors.Is(err, context.DeadlineExceeded) {
 		// only retry on messages that contain specific errors
-		if shouldRetry(ds.driverSettings.RetryOn, err.Error()) {
-			for i := 0; i < ds.driverSettings.Retries; i++ {
+		if shouldRetry(ds.DriverSettings().RetryOn, err.Error()) {
+			for i := 0; i < ds.DriverSettings().Retries; i++ {
 				backend.Logger.Warn(fmt.Sprintf("query failed: %s. Retrying %d times", err.Error(), i))
-				db, err := ds.dbReconnect(ctx, dbConn, q, cacheKey)
+				db, err := ds.connector.Reconnect(ctx, dbConn, q, cacheKey)
 				if err != nil {
 					return nil, DownstreamError(err)
 				}
 
-				if ds.driverSettings.Pause > 0 {
-					time.Sleep(time.Duration(ds.driverSettings.Pause * int(time.Second)))
+				if ds.DriverSettings().Pause > 0 {
+					time.Sleep(time.Duration(ds.DriverSettings().Pause * int(time.Second)))
 				}
 
-				dbQuery := NewQuery(db, dbConn.settings, ds.c.Converters(), fillMode)
+				dbQuery := NewQuery(db, dbConn.settings, ds.driver().Converters(), fillMode)
 				res, err = dbQuery.Run(ctx, q, args...)
 				if err == nil {
 					return res, err
 				}
-				if !shouldRetry(ds.driverSettings.RetryOn, err.Error()) {
+				if !shouldRetry(ds.DriverSettings().RetryOn, err.Error()) {
 					return res, err
 				}
 				backend.Logger.Warn(fmt.Sprintf("Retry failed: %s", err.Error()))
@@ -281,14 +221,14 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 
 	// allow retries on timeouts
 	if errors.Is(err, context.DeadlineExceeded) {
-		for i := 0; i < ds.driverSettings.Retries; i++ {
+		for i := 0; i < ds.DriverSettings().Retries; i++ {
 			backend.Logger.Warn(fmt.Sprintf("connection timed out. retrying %d times", i))
-			db, err := ds.dbReconnect(ctx, dbConn, q, cacheKey)
+			db, err := ds.connector.Reconnect(ctx, dbConn, q, cacheKey)
 			if err != nil {
 				continue
 			}
 
-			dbQuery := NewQuery(db, dbConn.settings, ds.c.Converters(), fillMode)
+			dbQuery := NewQuery(db, dbConn.settings, ds.driver().Converters(), fillMode)
 			res, err = dbQuery.Run(ctx, q, args...)
 			if err == nil {
 				return res, err
@@ -299,106 +239,20 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 	return res, err
 }
 
-func (ds *SQLDatasource) dbReconnect(ctx context.Context, dbConn dbConnection, q *Query, cacheKey string) (*sql.DB, error) {
-	if err := dbConn.db.Close(); err != nil {
-		backend.Logger.Warn(fmt.Sprintf("closing existing connection failed: %s", err.Error()))
-	}
-
-	db, err := ds.c.Connect(ctx, dbConn.settings, q.ConnectionArgs)
-	if err != nil {
-		return nil, DownstreamError(err)
-	}
-	ds.storeDBConnection(cacheKey, dbConnection{db, dbConn.settings})
-	return db, nil
-}
-
 // CheckHealth pings the connected SQL database
 func (ds *SQLDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	key := defaultKey(getDatasourceUID(*req.PluginContext.DataSourceInstanceSettings))
-	dbConn, ok := ds.getDBConnection(key)
-	if !ok {
-		return nil, ErrorMissingDBConnection
+	healthChecker := &HealthChecker{
+		Connector: ds.connector,
 	}
-
-	if ds.driverSettings.Retries == 0 {
-		return ds.check(dbConn)
-	}
-
-	return ds.checkWithRetries(ctx, dbConn, key, req.GetHTTPHeaders())
+	return healthChecker.Check(ctx, req)
 }
 
 func (ds *SQLDatasource) DriverSettings() DriverSettings {
-	return ds.driverSettings
+	return ds.connector.driverSettings
 }
 
-func (ds *SQLDatasource) checkWithRetries(ctx context.Context, conn dbConnection, key string, headers http.Header) (*backend.CheckHealthResult, error) {
-	var result *backend.CheckHealthResult
-
-	q := &Query{}
-	if ds.driverSettings.ForwardHeaders {
-		applyHeaders(q, headers)
-	}
-
-	for i := 0; i < ds.driverSettings.Retries; i++ {
-		db, err := ds.dbReconnect(ctx, conn, q, key)
-		if err != nil {
-			return nil, err
-		}
-		c := dbConnection{
-			db:       db,
-			settings: conn.settings,
-		}
-		result, err = ds.check(c)
-		if err == nil {
-			return result, err
-		}
-
-		if !shouldRetry(ds.driverSettings.RetryOn, err.Error()) {
-			break
-		}
-
-		if ds.driverSettings.Pause > 0 {
-			time.Sleep(time.Duration(ds.driverSettings.Pause * int(time.Second)))
-		}
-		backend.Logger.Warn(fmt.Sprintf("connect failed: %s. Retrying %d times", err.Error(), i))
-	}
-
-	// TODO: failed health checks don't return an error
-	return result, nil
-}
-
-func (ds *SQLDatasource) check(conn dbConnection) (*backend.CheckHealthResult, error) {
-	if err := ds.ping(conn); err != nil {
-		return &backend.CheckHealthResult{
-			Status:  backend.HealthStatusError,
-			Message: err.Error(),
-		}, DownstreamError(err)
-	}
-
-	return &backend.CheckHealthResult{
-		Status:  backend.HealthStatusOk,
-		Message: "Data source is working",
-	}, nil
-}
-
-func (ds *SQLDatasource) ping(conn dbConnection) error {
-	if ds.driverSettings.Timeout == 0 {
-		return conn.db.Ping()
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), ds.driverSettings.Timeout)
-	defer cancel()
-
-	return conn.db.PingContext(ctx)
-}
-
-func shouldRetry(retryOn []string, err string) bool {
-	for _, r := range retryOn {
-		if strings.Contains(err, r) {
-			return true
-		}
-	}
-	return false
+func (ds *SQLDatasource) driver() Driver {
+	return ds.connector.driver
 }
 
 func (ds *SQLDatasource) errors(response *Response) error {

--- a/datasource.go
+++ b/datasource.go
@@ -70,7 +70,7 @@ func (ds *SQLDatasource) NewDatasource(ctx context.Context, settings backend.Dat
 	}
 
 	ds.CallResourceHandler = httpadapter.New(mux)
-	ds.metrics = NewMetrics(settings.Name, settings.Type, KindQuery)
+	ds.metrics = NewMetrics(settings.Name, settings.Type, EndpointQuery)
 
 	return ds, nil
 }
@@ -245,7 +245,7 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 func (ds *SQLDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	healthChecker := &HealthChecker{
 		Connector: ds.connector,
-		Metrics:   ds.metrics.WithKind(KindHealth),
+		Metrics:   ds.metrics.WithEndpoint(EndpointHealth),
 	}
 	return healthChecker.Check(ctx, req)
 }

--- a/datasource.go
+++ b/datasource.go
@@ -245,7 +245,7 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 func (ds *SQLDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	healthChecker := &HealthChecker{
 		Connector: ds.connector,
-		Metrics:   ds.metrics.Clone().SetKind(KindHealth),
+		Metrics:   ds.metrics.WithKind(KindHealth),
 	}
 	return healthChecker.Check(ctx, req)
 }

--- a/datasource.go
+++ b/datasource.go
@@ -52,6 +52,7 @@ type SQLDatasource struct {
 	// are hit. The datasource enabling this should make sure connections are cached
 	// if necessary.
 	EnableMultipleConnections bool
+	metrics                   Metrics
 }
 
 // NewDatasource creates a new `SQLDatasource`.
@@ -69,6 +70,7 @@ func (ds *SQLDatasource) NewDatasource(ctx context.Context, settings backend.Dat
 	}
 
 	ds.CallResourceHandler = httpadapter.New(mux)
+	ds.metrics = NewMetrics(settings.Name, settings.Type, KindQuery)
 
 	return ds, nil
 }
@@ -243,6 +245,7 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 func (ds *SQLDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	healthChecker := &HealthChecker{
 		Connector: ds.connector,
+		Metrics:   ds.metrics.Clone().SetKind(KindHealth),
 	}
 	return healthChecker.Check(ctx, req)
 }

--- a/datasource_connect_test.go
+++ b/datasource_connect_test.go
@@ -77,7 +77,7 @@ func Test_getDBConnectionFromQuery(t *testing.T) {
 				conn.storeDBConnection(key, dbConnection{tt.existingDB, settings})
 			}
 
-			key, dbConn, err := conn.GetConnectionFromQuery(context.Background(), &Query{ConnectionArgs: json.RawMessage(tt.args)}, tt.dsUID)
+			key, dbConn, err := conn.GetConnectionFromQuery(context.Background(), &Query{ConnectionArgs: json.RawMessage(tt.args)})
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
@@ -92,7 +92,7 @@ func Test_getDBConnectionFromQuery(t *testing.T) {
 
 	t.Run("it should return an error if connection args are used without enabling multiple connections", func(t *testing.T) {
 		conn := &Connector{driver: d, enableMultipleConnections: false}
-		_, _, err := conn.GetConnectionFromQuery(context.Background(), &Query{ConnectionArgs: json.RawMessage("foo")}, "dsUID")
+		_, _, err := conn.GetConnectionFromQuery(context.Background(), &Query{ConnectionArgs: json.RawMessage("foo")})
 		if err == nil || !errors.Is(err, MissingMultipleConnectionsConfig) {
 			t.Errorf("expecting error: %v", MissingMultipleConnectionsConfig)
 		}
@@ -100,7 +100,7 @@ func Test_getDBConnectionFromQuery(t *testing.T) {
 
 	t.Run("it should return an error if the default connection is missing", func(t *testing.T) {
 		conn := &Connector{driver: d}
-		_, _, err := conn.GetConnectionFromQuery(context.Background(), &Query{}, "dsUID")
+		_, _, err := conn.GetConnectionFromQuery(context.Background(), &Query{})
 		if err == nil || !errors.Is(err, MissingDBConnection) {
 			t.Errorf("expecting error: %v", MissingDBConnection)
 		}

--- a/health.go
+++ b/health.go
@@ -1,0 +1,40 @@
+package sqlds
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var healthExternalDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "plugins",
+	Name:      "plugin_health_esternal_duration_seconds",
+	Help:      "Duration of external plugin health check",
+}, []string{"datasource_name", "datasource_type", "error_source"})
+
+type HealthChecker struct {
+	Connector *Connector
+}
+
+func (hc *HealthChecker) Check(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	start := time.Now()
+
+	settings := req.PluginContext.DataSourceInstanceSettings
+	_, err := hc.Connector.Connect(ctx, req.GetHTTPHeaders())
+	if err != nil {
+		healthExternalDuration.WithLabelValues(settings.Name, settings.Type, string(ErrorSource(err))).Observe(time.Since(start).Seconds())
+		return &backend.CheckHealthResult{
+			Status:  backend.HealthStatusError,
+			Message: err.Error(),
+		}, DownstreamError(err)
+	}
+	healthExternalDuration.WithLabelValues(settings.Name, settings.Type, "none").Observe(time.Since(start).Seconds())
+
+	return &backend.CheckHealthResult{
+		Status:  backend.HealthStatusOk,
+		Message: "Data source is working",
+	}, nil
+}

--- a/metrics.go
+++ b/metrics.go
@@ -42,13 +42,8 @@ func NewMetrics(dsName, dsType string, kind Kind) Metrics {
 	return Metrics{DSName: dsName, DSType: dsType, Kind: kind}
 }
 
-func (m *Metrics) Clone() *Metrics {
-	return &Metrics{DSName: m.DSName, DSType: m.DSType, Kind: m.Kind}
-}
-
-func (m *Metrics) SetKind(kind Kind) Metrics {
-	m.Kind = kind
-	return *m
+func (m *Metrics) WithKind(kind Kind) Metrics {
+	return Metrics{DSName: m.DSName, DSType: m.DSType, Kind: m.Kind}
 }
 
 func (m *Metrics) CollectDuration(source Source, status Status, duration float64) {

--- a/metrics.go
+++ b/metrics.go
@@ -10,9 +10,9 @@ import (
 )
 
 type Metrics struct {
-	DSName string
-	DSType string
-	Endpoint   Endpoint
+	DSName   string
+	DSType   string
+	Endpoint Endpoint
 }
 
 type Status string
@@ -20,12 +20,12 @@ type Endpoint string
 type Source string
 
 const (
-	StatusOK         Status = "ok"
-	StatusError      Status = "error"
-	EndpointHealth       Endpoint   = "health"
-	EndpointQuery        Endpoint  = "query"
-	SourceDownstream Source = "downstream"
-	SourcePlugin     Source = "plugin"
+	StatusOK         Status   = "ok"
+	StatusError      Status   = "error"
+	EndpointHealth   Endpoint = "health"
+	EndpointQuery    Endpoint = "query"
+	SourceDownstream Source   = "downstream"
+	SourcePlugin     Source   = "plugin"
 )
 
 var durationMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
@@ -34,20 +34,20 @@ var durationMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Help:      "Duration of plugin execution",
 }, []string{"datasource_name", "datasource_type", "source", "endpoint", "status"})
 
-func NewMetrics(dsName, dsType string, kind Kind) Metrics {
+func NewMetrics(dsName, dsType string, endpoint Endpoint) Metrics {
 	dsName, ok := sanitizeLabelName(dsName)
 	if !ok {
 		backend.Logger.Warn("Failed to sanitize datasource name for prometheus label", dsName)
 	}
-	return Metrics{DSName: dsName, DSType: dsType, Kind: kind}
+	return Metrics{DSName: dsName, DSType: dsType, Endpoint: endpoint}
 }
 
-func (m *Metrics) WithKind(kind Kind) Metrics {
-	return Metrics{DSName: m.DSName, DSType: m.DSType, Kind: m.Kind}
+func (m *Metrics) WithEndpoint(endpoint Endpoint) Metrics {
+	return Metrics{DSName: m.DSName, DSType: m.DSType, Endpoint: endpoint}
 }
 
 func (m *Metrics) CollectDuration(source Source, status Status, duration float64) {
-	durationMetric.WithLabelValues(m.DSName, m.DSType, string(source), string(m.Kind), string(status)).Observe(duration)
+	durationMetric.WithLabelValues(m.DSName, m.DSType, string(source), string(m.Endpoint), string(status)).Observe(duration)
 }
 
 // sanitizeLabelName removes all invalid chars from the label name.

--- a/metrics.go
+++ b/metrics.go
@@ -16,7 +16,7 @@ type Metrics struct {
 }
 
 type Status string
-type Kind string
+type Endpoint string
 type Source string
 
 const (

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,82 @@
+package sqlds
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type Metrics struct {
+	DSName string
+	DSType string
+	Kind   Kind
+}
+
+type Status string
+type Kind string
+type Source string
+
+const (
+	StatusOK         Status = "ok"
+	StatusError      Status = "error"
+	KindHealth       Kind   = "health"
+	KindQuery        Kind   = "query"
+	SourceDownstream Source = "downstream"
+	SourcePlugin     Source = "plugin"
+)
+
+var durationMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "plugins",
+	Name:      "plugin_request_duration_seconds",
+	Help:      "Duration of plugin execution",
+}, []string{"datasource_name", "datasource_type", "source", "type", "status"})
+
+func NewMetrics(dsName, dsType string, kind Kind) Metrics {
+	dsName, ok := sanitizeLabelName(dsName)
+	if !ok {
+		backend.Logger.Warn("Failed to sanitize datasource name for prometheus label", dsName)
+	}
+	return Metrics{DSName: dsName, DSType: dsType, Kind: kind}
+}
+
+func (m *Metrics) Clone() *Metrics {
+	return &Metrics{DSName: m.DSName, DSType: m.DSType, Kind: m.Kind}
+}
+
+func (m *Metrics) SetKind(kind Kind) Metrics {
+	m.Kind = kind
+	return *m
+}
+
+func (m *Metrics) CollectDuration(source Source, status Status, duration float64) {
+	durationMetric.WithLabelValues(m.DSName, m.DSType, string(source), string(m.Kind), string(status)).Observe(duration)
+}
+
+// sanitizeLabelName removes all invalid chars from the label name.
+// If the label name is empty or contains only invalid chars, it will return false indicating it was not sanitized.
+// copied from https://github.com/grafana/grafana/blob/main/pkg/infra/metrics/metricutil/utils.go#L14
+func sanitizeLabelName(name string) (string, bool) {
+	if len(name) == 0 {
+		backend.Logger.Warn(fmt.Sprintf("label name cannot be empty: %s", name))
+		return "", false
+	}
+
+	out := strings.Builder{}
+	for i, b := range name {
+		if (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || (b >= '0' && b <= '9' && i > 0) {
+			out.WriteRune(b)
+		} else if b == ' ' {
+			out.WriteRune('_')
+		}
+	}
+
+	if out.Len() == 0 {
+		backend.Logger.Warn(fmt.Sprintf("label name only contains invalid chars: %q", name))
+		return "", false
+	}
+
+	return out.String(), true
+}

--- a/metrics.go
+++ b/metrics.go
@@ -12,7 +12,7 @@ import (
 type Metrics struct {
 	DSName string
 	DSType string
-	Kind   Kind
+	Endpoint   Endpoint
 }
 
 type Status string

--- a/metrics.go
+++ b/metrics.go
@@ -22,8 +22,8 @@ type Source string
 const (
 	StatusOK         Status = "ok"
 	StatusError      Status = "error"
-	KindHealth       Kind   = "health"
-	KindQuery        Kind   = "query"
+	EndpointHealth       Endpoint   = "health"
+	EndpointQuery        Endpoint  = "query"
 	SourceDownstream Source = "downstream"
 	SourcePlugin     Source = "plugin"
 )

--- a/metrics.go
+++ b/metrics.go
@@ -32,7 +32,7 @@ var durationMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Namespace: "plugins",
 	Name:      "plugin_request_duration_seconds",
 	Help:      "Duration of plugin execution",
-}, []string{"datasource_name", "datasource_type", "source", "type", "status"})
+}, []string{"datasource_name", "datasource_type", "source", "endpoint", "status"})
 
 func NewMetrics(dsName, dsType string, kind Kind) Metrics {
 	dsName, ok := sanitizeLabelName(dsName)

--- a/query.go
+++ b/query.go
@@ -66,7 +66,7 @@ func NewQuery(db Connection, settings backend.DataSourceInstanceSettings, conver
 		DSName:     settings.Name,
 		converters: converters,
 		fillMode:   fillMode,
-		metrics:    NewMetrics(settings.Name, settings.Type, KindQuery),
+		metrics:    NewMetrics(settings.Name, settings.Type, EndpointQuery),
 	}
 }
 


### PR DESCRIPTION
For SLO metrics for all sqlds clients
* fix query duration to capture both external and internal duration
* add health check external duration ( doesn't really seem to do anything internally )
* refactor - move/delegate connectivity logic to a connector
* refactor - move/delegate health check logic to a health checker