### PR TITLE
multi-mode: return error for unsupported shape

### DIFF
--- a/dataframe_test.go
+++ b/dataframe_test.go
@@ -188,3 +188,128 @@ func TestNoRowsFrame(t *testing.T) {
 		})
 	}
 }
+
+func TestMulti(t *testing.T) {
+
+	tts := []struct {
+		name               string
+		data               test.Data
+		expectError        bool
+		expectedFrameCount int
+	}{
+		{
+			name: "table",
+			data: test.Data{
+				Cols: []test.Column{
+					{
+						Name:     "name",
+						DataType: "TEXT",
+						Kind:     "",
+					},
+					{
+						Name:     "age",
+						DataType: "INTEGER",
+						Kind:     int64(0),
+					},
+				},
+				Rows: [][]any{
+					{"jill", 41},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "wide",
+			data: test.Data{
+				Cols: []test.Column{
+					{
+						Name:     "time",
+						DataType: "TIMESTAMP",
+						Kind:     time.Unix(0, 0),
+					},
+					{
+						Name:     "one",
+						DataType: "FLOAT",
+						Kind:     float64(0),
+					},
+					{
+						Name:     "two",
+						DataType: "FLOAT",
+						Kind:     float64(0),
+					},
+				},
+				Rows: [][]any{
+					{time.Unix(1, 0), 41, 42},
+					{time.Unix(2, 0), 21, 22},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "long",
+			data: test.Data{
+				Cols: []test.Column{
+					{
+						Name:     "time",
+						DataType: "TIMESTAMP",
+						Kind:     time.Unix(0, 0),
+					},
+					{
+						Name:     "tag",
+						DataType: "TEXT",
+						Kind:     "",
+					},
+					{
+						Name:     "value",
+						DataType: "FLOAT",
+						Kind:     float64(0),
+					},
+				},
+				Rows: [][]any{
+					{time.Unix(1, 0), "one", 41},
+					{time.Unix(1, 0), "two", 42},
+					{time.Unix(2, 0), "one", 21},
+					{time.Unix(2, 0), "two", 22},
+				},
+			},
+			expectedFrameCount: 2,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			id := "multi-frames" + tt.name
+			driver, _ := test.NewDriver(id, tt.data, nil, test.DriverOpts{})
+			ds := sqlds.NewDatasource(driver)
+
+			settings := backend.DataSourceInstanceSettings{UID: id, JSONData: []byte("{}")}
+			_, err := ds.NewDatasource(context.Background(), settings)
+
+			require.NoError(t, err)
+
+			req := backend.QueryDataRequest{
+				PluginContext: backend.PluginContext{
+					DataSourceInstanceSettings: &settings,
+				},
+				Queries: []backend.DataQuery{
+					{
+						RefID: "A",
+						JSON:  []byte(fmt.Sprintf(`{ "rawSql": "SELECT 42", "format": %d }`, sqlutil.FormatOptionMulti)),
+					},
+				},
+			}
+
+			r, err := ds.QueryData(context.Background(), &req)
+			require.NoError(t, err)
+			d := r.Responses["A"]
+			if tt.expectError {
+				require.Error(t, d.Error)
+
+			} else {
+				require.NoError(t, d.Error)
+				require.NotNil(t, d)
+				require.Len(t, d.Frames, tt.expectedFrameCount)
+			}
+		})
+	}
+}

--- a/query.go
+++ b/query.go
@@ -156,6 +156,10 @@ func getFrames(rows *sql.Rows, limit int64, converters []sqlutil.Converter, fill
 				return nil, err
 			}
 			return frames.Frames(), nil
+		} else {
+			// TODO: handle the other possible shapes,
+			// wide or tabule data.
+			return nil, errors.New("FormatOptionMulti: unsupported data shape")
 		}
 	case FormatOptionTable:
 		frame.Meta.PreferredVisualization = data.VisTypeTable


### PR DESCRIPTION
the `format=sqlutil.FormatOptionMulti` is not complete yet, it only handles `long` dataframes, nothing else. this PR makes the code return an error for other data-shapes (until now it just returned the original data, unmodified).

i think it's better to return an error in this case for now, we don't want people to start to use this and then rely on the current behavior for data-shapes we do not handle yet. WDYT?

(NOTE: as this error-message is only temporary, until we add full support, i did not do the "proper" thing to add it to `errors.go`.. but i can do that if it's necessary)