### PR TITLE
Bump version to 4.0.0

### DIFF
--- a/dataframe_test.go
+++ b/dataframe_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
-	"github.com/grafana/sqlds/v3"
-	"github.com/grafana/sqlds/v3/test"
+	"github.com/grafana/sqlds/v4"
+	"github.com/grafana/sqlds/v4/test"
 	"github.com/stretchr/testify/require"
 )
 

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/sqlds/v3"
-	"github.com/grafana/sqlds/v3/test"
+	"github.com/grafana/sqlds/v4"
+	"github.com/grafana/sqlds/v4/test"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/grafana/sqlds/v3
+module github.com/grafana/sqlds/v4
 
 go 1.21
 

--- a/mock/csv/csv_mock.go
+++ b/mock/csv/csv_mock.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
-	"github.com/grafana/sqlds/v3"
+	"github.com/grafana/sqlds/v4"
 	_ "github.com/mithrandie/csvq-driver"
 )
 

--- a/test/driver.go
+++ b/test/driver.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
-	"github.com/grafana/sqlds/v3"
-	"github.com/grafana/sqlds/v3/mock"
+	"github.com/grafana/sqlds/v4"
+	"github.com/grafana/sqlds/v4/mock"
 )
 
 var registered = map[string]*SqlHandler{}


### PR DESCRIPTION
There was previously a breaking change in https://github.com/grafana/sqlds/releases/tag/v3.4.0 from [removing the `QueryDB` function](https://github.com/grafana/sqlds/pull/116/files#diff-66f9c6b00ef4ad1dbef1133865440121c8d03aec3333e8b6dd97ac3560b91ac7L55). Releasing v4.0.0 to indicate this breaking change.