### PR TITLE
sqlds - Allow ctx mod

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -98,6 +98,10 @@ func (ds *SQLDatasource) QueryData(ctx context.Context, req *backend.QueryDataRe
 
 	wg.Add(len(req.Queries))
 
+	if queryDataMutator, ok := ds.driver().(QueryDataMutator); ok {
+		ctx, req = queryDataMutator.MutateQueryData(ctx, req)
+	}
+
 	// Execute each query and store the results by query RefID
 	for _, q := range req.Queries {
 		go func(query backend.DataQuery) {

--- a/datasource.go
+++ b/datasource.go
@@ -247,6 +247,9 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 
 // CheckHealth pings the connected SQL database
 func (ds *SQLDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	if queryDataMutator, ok := ds.driver().(CheckHealthMutator); ok {
+		ctx, req = queryDataMutator.MutateCheckHealth(ctx, req)
+	}
 	healthChecker := &HealthChecker{
 		Connector: ds.connector,
 		Metrics:   ds.metrics.WithEndpoint(EndpointHealth),

--- a/datasource.go
+++ b/datasource.go
@@ -247,8 +247,8 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 
 // CheckHealth pings the connected SQL database
 func (ds *SQLDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	if queryDataMutator, ok := ds.driver().(CheckHealthMutator); ok {
-		ctx, req = queryDataMutator.MutateCheckHealth(ctx, req)
+	if checkHealthMutator, ok := ds.driver().(CheckHealthMutator); ok {
+		ctx, req = checkHealthMutator.MutateCheckHealth(ctx, req)
 	}
 	healthChecker := &HealthChecker{
 		Connector: ds.connector,

--- a/driver.go
+++ b/driver.go
@@ -45,10 +45,14 @@ type Connection interface {
 // QueryDataMutator  is an additional interface that could be implemented by driver.
 // This adds ability to the driver to optionally mutate the query before it's run
 // with the QueryDataRequest.
-// This is useful when we need to access properties of the request before the query is run.
-// or when we want to enhance the ctx with additional information.
 type QueryDataMutator interface {
 	MutateQueryData(ctx context.Context, req *backend.QueryDataRequest) (context.Context, *backend.QueryDataRequest)
+}
+
+// CheckHealthMutator  is an additional interface that could be implemented by driver.
+// This adds ability to the driver to optionally mutate the CheckHealth before it's run
+type CheckHealthMutator interface {
+	MutateCheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (context.Context, *backend.CheckHealthRequest)
 }
 
 // QueryMutator is an additional interface that could be implemented by driver.

--- a/driver.go
+++ b/driver.go
@@ -42,6 +42,15 @@ type Connection interface {
 	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 }
 
+// QueryDataMutator  is an additional interface that could be implemented by driver.
+// This adds ability to the driver to optionally mutate the query before it's run
+// with the QueryDataRequest.
+// This is useful when we need to access properties of the request before the query is run.
+// or when we want to enhance the ctx with additional information.
+type QueryDataMutator interface {
+	MutateQueryData(ctx context.Context, req *backend.QueryDataRequest) (context.Context, *backend.QueryDataRequest)
+}
+
 // QueryMutator is an additional interface that could be implemented by driver.
 // This adds ability to the driver it can mutate query before run.
 type QueryMutator interface {


### PR DESCRIPTION
This PR adds some hooks to access the `ctx` and the `req` that run on `CheckHealth` and `QueryData`

This allows clients to access them for example to enhance the `ctx` with `azusercontext` functions from the azure-sdk-go:

https://github.com/grafana/grafana-azure-sdk-go/blob/183b82f0a788fc0cd5d97bb133a0acb4232a9d42/azusercontext/context.go#L19-L26