### PR TITLE
Check health mutator tweak

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -60,6 +60,7 @@ func (c *Connector) Connect(ctx context.Context, headers http.Header) (*dbConnec
 func (c *Connector) connectWithRetries(ctx context.Context, conn dbConnection, key string, headers http.Header) error {
 	q := &Query{}
 	if c.driverSettings.ForwardHeaders {
+		// TODO: 4 After this point the headers are now forwarded
 		applyHeaders(q, headers)
 	}
 

--- a/connector.go
+++ b/connector.go
@@ -60,7 +60,6 @@ func (c *Connector) Connect(ctx context.Context, headers http.Header) (*dbConnec
 func (c *Connector) connectWithRetries(ctx context.Context, conn dbConnection, key string, headers http.Header) error {
 	q := &Query{}
 	if c.driverSettings.ForwardHeaders {
-		// TODO: 4 After this point the headers are now forwarded
 		applyHeaders(q, headers)
 	}
 

--- a/datasource.go
+++ b/datasource.go
@@ -247,14 +247,24 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 
 // CheckHealth pings the connected SQL database
 func (ds *SQLDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	// TODO: 1 - Move this...
 	if checkHealthMutator, ok := ds.driver().(CheckHealthMutator); ok {
 		ctx, req = checkHealthMutator.MutateCheckHealth(ctx, req)
 	}
+	// TODO: Move this its too early for the ctx and req yet
 	healthChecker := &HealthChecker{
 		Connector: ds.connector,
 		Metrics:   ds.metrics.WithEndpoint(EndpointHealth),
 	}
+	// TODO: Its early beacause the headers get forwarded in this function
+	// But at that point we're already returning the CheckHealthResult
 	return healthChecker.Check(ctx, req)
+
+	// TODO: 5 So instead we need the MutateCheckHealth function to
+	// be called with a backend.CheckHealthResult as a parameter
+	// to also return it if need be
+	// that way this is not a breaking change
+	// and token providers can be used
 }
 
 func (ds *SQLDatasource) DriverSettings() DriverSettings {

--- a/datasource.go
+++ b/datasource.go
@@ -247,24 +247,11 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 
 // CheckHealth pings the connected SQL database
 func (ds *SQLDatasource) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	// TODO: 1 - Move this...
-	if checkHealthMutator, ok := ds.driver().(CheckHealthMutator); ok {
-		ctx, req = checkHealthMutator.MutateCheckHealth(ctx, req)
-	}
-	// TODO: Move this its too early for the ctx and req yet
 	healthChecker := &HealthChecker{
 		Connector: ds.connector,
 		Metrics:   ds.metrics.WithEndpoint(EndpointHealth),
 	}
-	// TODO: Its early beacause the headers get forwarded in this function
-	// But at that point we're already returning the CheckHealthResult
 	return healthChecker.Check(ctx, req, ds)
-
-	// TODO: 5 So instead we need the MutateCheckHealth function to
-	// be called with a backend.CheckHealthResult as a parameter
-	// to also return it if need be
-	// that way this is not a breaking change
-	// and token providers can be used
 }
 
 func (ds *SQLDatasource) DriverSettings() DriverSettings {

--- a/datasource.go
+++ b/datasource.go
@@ -258,7 +258,7 @@ func (ds *SQLDatasource) CheckHealth(ctx context.Context, req *backend.CheckHeal
 	}
 	// TODO: Its early beacause the headers get forwarded in this function
 	// But at that point we're already returning the CheckHealthResult
-	return healthChecker.Check(ctx, req)
+	return healthChecker.Check(ctx, req, ds)
 
 	// TODO: 5 So instead we need the MutateCheckHealth function to
 	// be called with a backend.CheckHealthResult as a parameter

--- a/health.go
+++ b/health.go
@@ -12,22 +12,20 @@ type HealthChecker struct {
 	Metrics   Metrics
 }
 
-func (hc *HealthChecker) Check(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+func (hc *HealthChecker) Check(ctx context.Context, req *backend.CheckHealthRequest, ds *SQLDatasource) (*backend.CheckHealthResult, error) {
 	start := time.Now()
-
-	// TODO: 2 This starts the connection after CheckHealth is called.
-	// after this line the headers are now forwarded
 	_, err := hc.Connector.Connect(ctx, req.GetHTTPHeaders())
-	// TODO: 3 Move checkealthMutator here
-	// because after this point we have the most current headers
-	//
-	// TODO: 4 but if we move it here then it'd be a breaking change for other sqlds clients
 	if err != nil {
 		hc.Metrics.CollectDuration(SourceDownstream, StatusError, time.Since(start).Seconds())
 		return &backend.CheckHealthResult{
 			Status:  backend.HealthStatusError,
 			Message: err.Error(),
 		}, DownstreamError(err)
+	}
+
+	if checkHealthMutator, ok := ds.driver().(CheckHealthMutator); ok {
+		// If you need to use ctx and req after this point you can grab it from the return values
+		checkHealthMutator.MutateCheckHealth(ctx, req)
 	}
 	hc.Metrics.CollectDuration(SourceDownstream, StatusOK, time.Since(start).Seconds())
 

--- a/health.go
+++ b/health.go
@@ -15,7 +15,13 @@ type HealthChecker struct {
 func (hc *HealthChecker) Check(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	start := time.Now()
 
+	// TODO: 2 This starts the connection after CheckHealth is called.
+	// after this line the headers are now forwarded
 	_, err := hc.Connector.Connect(ctx, req.GetHTTPHeaders())
+	// TODO: 3 Move checkealthMutator here
+	// because after this point we have the most current headers
+	//
+	// TODO: 4 but if we move it here then it'd be a breaking change for other sqlds clients
 	if err != nil {
 		hc.Metrics.CollectDuration(SourceDownstream, StatusError, time.Since(start).Seconds())
 		return &backend.CheckHealthResult{

--- a/health.go
+++ b/health.go
@@ -15,10 +15,6 @@ type HealthChecker struct {
 func (hc *HealthChecker) Check(ctx context.Context, req *backend.CheckHealthRequest, ds *SQLDatasource) (*backend.CheckHealthResult, error) {
 	start := time.Now()
 	_, err := hc.Connector.Connect(ctx, req.GetHTTPHeaders())
-	// TODO: 3 Move checkealthMutator here
-	// because after this point we have the most current headers
-	//
-	// TODO: 4 but if we move it here then it'd be a breaking change for other sqlds clients
 	if err != nil {
 		hc.Metrics.CollectDuration(SourceDownstream, StatusError, time.Since(start).Seconds())
 		return &backend.CheckHealthResult{

--- a/health.go
+++ b/health.go
@@ -15,6 +15,10 @@ type HealthChecker struct {
 func (hc *HealthChecker) Check(ctx context.Context, req *backend.CheckHealthRequest, ds *SQLDatasource) (*backend.CheckHealthResult, error) {
 	start := time.Now()
 	_, err := hc.Connector.Connect(ctx, req.GetHTTPHeaders())
+	// TODO: 3 Move checkealthMutator here
+	// because after this point we have the most current headers
+	//
+	// TODO: 4 but if we move it here then it'd be a breaking change for other sqlds clients
 	if err != nil {
 		hc.Metrics.CollectDuration(SourceDownstream, StatusError, time.Since(start).Seconds())
 		return &backend.CheckHealthResult{

--- a/query.go
+++ b/query.go
@@ -44,7 +44,6 @@ func GetQuery(query backend.DataQuery, headers http.Header, setHeaders bool) (*Q
 	}
 
 	if setHeaders {
-		// TODO: 5 this is the highest place where the headers are set
 		applyHeaders(model, headers)
 	}
 

--- a/query.go
+++ b/query.go
@@ -39,12 +39,12 @@ type Query = sqlutil.Query
 // GetQuery wraps sqlutil's GetQuery to add headers if needed
 func GetQuery(query backend.DataQuery, headers http.Header, setHeaders bool) (*Query, error) {
 	model, err := sqlutil.GetQuery(query)
-
 	if err != nil {
 		return nil, PluginError(err)
 	}
 
 	if setHeaders {
+		// TODO: 5 this is the highest place where the headers are set
 		applyHeaders(model, headers)
 	}
 

--- a/query.go
+++ b/query.go
@@ -44,6 +44,7 @@ func GetQuery(query backend.DataQuery, headers http.Header, setHeaders bool) (*Q
 	}
 
 	if setHeaders {
+		// TODO: 5 this is the highest place where the headers are set
 		applyHeaders(model, headers)
 	}
 


### PR DESCRIPTION
Moves the CheckHealthMutator inside of the `Check` function instead so that tokenproviders can access the modified headers in the req.

The previous location was ok just for `ctx` but `req` was being modified at a later point in the code so now its at the latest point where either of them get modified.