### PR TITLE
fix: implement InstanceDisposer to close db connections

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -134,6 +134,15 @@ func (ds *Connector) storeDBConnection(key string, dbConn dbConnection) {
 	ds.connections.Store(key, dbConn)
 }
 
+// Dispose is called when a new SQLDatasource is c
+func (c *Connector) Dispose() {
+	c.connections.Range(func(_, conn interface{}) bool {
+		_ = conn.(dbConnection).db.Close()
+		return true
+	})
+	c.connections.Clear()
+}
+
 func (c *Connector) GetConnectionFromQuery(ctx context.Context, q *Query) (string, dbConnection, error) {
 	if !c.enableMultipleConnections && !c.driverSettings.ForwardHeaders && len(q.ConnectionArgs) > 0 {
 		return "", dbConnection{}, MissingMultipleConnectionsConfig

--- a/connector.go
+++ b/connector.go
@@ -134,7 +134,7 @@ func (ds *Connector) storeDBConnection(key string, dbConn dbConnection) {
 	ds.connections.Store(key, dbConn)
 }
 
-// Dispose is called when a new SQLDatasource is c
+// Dispose is called when an existing SQLDatasource needs to be replaced
 func (c *Connector) Dispose() {
 	c.connections.Range(func(_, conn interface{}) bool {
 		_ = conn.(dbConnection).db.Close()

--- a/datasource.go
+++ b/datasource.go
@@ -85,6 +85,7 @@ func NewDatasource(c Driver) *SQLDatasource {
 // Dispose cleans up datasource instance resources.
 // Note: Called when testing and saving a datasource
 func (ds *SQLDatasource) Dispose() {
+	ds.connector.Dispose()
 }
 
 // QueryData creates the Responses list and executes each query


### PR DESCRIPTION
This adds support for the `InstanceDisposer()` interface to `SQLDatasource`, to fix a connection leak.

Fixes #135