### PR TITLE
fix: mark bad macros arguments count error as downstream

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -153,6 +153,9 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 	// Apply supported macros to the query
 	q.RawSQL, err = Interpolate(ds.driver(), q)
 	if err != nil {
+		if errors.Is(err, sqlutil.ErrorBadArgumentCount) {
+			err = backend.DownstreamError(err)
+		}
 		return sqlutil.ErrorFrameFromQuery(q), fmt.Errorf("%s: %w", "Could not apply macros", err)
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -29,9 +29,8 @@ func DownstreamError(err error, override ...bool) error {
 }
 
 func ErrorSource(err error) backend.ErrorSource {
-	var se es.Error
-	if errors.As(err, &se) {
-		return se.Source()
+	if backend.IsDownstreamError(err) {
+		return backend.ErrorSourceDownstream
 	}
 	return backend.ErrorSourcePlugin
 }


### PR DESCRIPTION
Logs before:

```
statusSource=plugin error="Could not apply macros: unexpected number of arguments: expected 1 argument, received 2"
```

Logs after:

```
statusSource=downstream error="Could not apply macros: downstream error: unexpected number of arguments: expected 1 argument, received 2"
```