### PR TITLE
fix: return error if not nil when connecting

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -77,7 +77,7 @@ func (c *Connector) connectWithRetries(ctx context.Context, conn dbConnection, k
 		err = c.connect(conn)
 		if err != nil {
 			if !shouldRetry(c.driverSettings.RetryOn, err.Error()) {
-				return err
+				break
 			}
 
 			if c.driverSettings.Pause > 0 {


### PR DESCRIPTION
When implementing PDC for the Aurora data source, the healthcheck was always returning a success response even if the PDC agent was not running. This PR returns the error in `connectWithRetries` if one is present and the connection should not be retried.