### PR TITLE
Enable dataproxy.row_limit configuration option from Grafana

### DIFF
--- a/query_integration_test.go
+++ b/query_integration_test.go
@@ -79,7 +79,7 @@ func TestQuery_MySQL(t *testing.T) {
 			Name: "foo",
 		}
 
-		sqlQuery := NewQuery(db, settings, []sqlutil.Converter{}, nil)
+		sqlQuery := NewQuery(db, settings, []sqlutil.Converter{}, nil, defaultRowLimit)
 		_, err := sqlQuery.Run(ctx, q)
 		if err == nil {
 			t.Fatal("expected an error but received none")

--- a/query_test.go
+++ b/query_test.go
@@ -84,7 +84,7 @@ func TestQuery_Timeout(t *testing.T) {
 			Name: "foo",
 		}
 
-		sqlQuery := NewQuery(conn, settings, []sqlutil.Converter{}, nil)
+		sqlQuery := NewQuery(conn, settings, []sqlutil.Converter{}, nil, defaultRowLimit)
 		_, err := sqlQuery.Run(ctx, &Query{})
 
 		if !errors.Is(err, context.Canceled) {
@@ -111,7 +111,7 @@ func TestQuery_Timeout(t *testing.T) {
 			Name: "foo",
 		}
 
-		sqlQuery := NewQuery(conn, settings, []sqlutil.Converter{}, nil)
+		sqlQuery := NewQuery(conn, settings, []sqlutil.Converter{}, nil, defaultRowLimit)
 		_, err := sqlQuery.Run(ctx, &Query{})
 
 		if !errors.Is(err, ErrorQuery) {


### PR DESCRIPTION
This enables use of the [dataproxy.row_limit](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#row_limit) setting. Currently this is used in some other SQL data sources (e.g. MySQL and PostgreSQL).

`sqlds` currently doesn't make use of this setting so sqlds-based data sources might be returning too many rows if the query doesn't have any limits set on it (for instance using the `LIMIT` keyword).

This change makes using the `dataproxy.row_limit` option opt-in for the data source. It will continue using the `-1` that was previously set, i.e. no limit on the number of the rows returned. However, there is still a breaking change as the signature for `NewQuery` in `query.go` is changed. AFAICT, our squad is the [only user of `NewQuery`](https://github.com/search?q=%2F%28%3F-i%29sqlds.NewQuery%5C%28%2F+language%3AGo&type=code) outside of `sqlds` itself.