### PR TITLE
Improve error handling

### DIFF
--- a/datasource_test.go
+++ b/datasource_test.go
@@ -269,7 +269,7 @@ func Test_query_panic_in_rows_validation(t *testing.T) {
 
 	res := data.Responses["foo"]
 	assert.NotNil(t, res.Error)
-	assert.Contains(t, res.Error.Error(), "failed to validate rows")
+	assert.Contains(t, res.Error.Error(), "SQL rows validation failed")
 	assert.NotNil(t, res.Frames) // Error frame is returned, not nil
 }
 


### PR DESCRIPTION
Treat SQL errors as downstream and add PGX-specific errors. There was a change between v4 and v5 how the lib works so we should account for this.