### PR TITLE
Pass down Context to Ping method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.6]
+
+### Changed
+- Pass down Context to Ping method (#179)
+
 ## [4.2.5]
 
 ### Changed

--- a/health_test.go
+++ b/health_test.go
@@ -88,13 +88,17 @@ func TestHealthChecker_Check(t *testing.T) {
 			if want == nil {
 				want = &backend.CheckHealthResult{Status: backend.HealthStatusOk, Message: "Data source is working"}
 			}
+			ctx := tt.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
 			hc := &sqlds.HealthChecker{
 				Connector:       connector,
 				Metrics:         tt.Metrics,
 				PreCheckHealth:  tt.PreCheckHealth,
 				PostCheckHealth: tt.PostCheckHealth,
 			}
-			got, err := hc.Check(tt.ctx, req)
+			got, err := hc.Check(ctx, req)
 			if tt.wantErr != nil {
 				require.NotNil(t, err)
 				assert.Equal(t, tt.wantErr.Error(), err.Error())


### PR DESCRIPTION
- Updated the `connect` and `ping` methods in the `Connector` struct to accept a `context.Context` parameter, improving the handling of database operations with context support.
- Adjusted calls to these methods in `Connect` and `connectWithRetries` to pass the context, enhancing error handling and timeout management.

This is needed for https://github.com/grafana/google-bigquery-datasource/pull/346 to work when user tests data source.