### PR TITLE
QueryErrorMutator interface

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -73,3 +73,7 @@ type QueryArgSetter interface {
 type ResponseMutator interface {
 	MutateResponse(ctx context.Context, res data.Frames) (data.Frames, error)
 }
+
+type QueryErrorMutator interface {
+	MutateQueryError(err error) backend.ErrorWithSource
+}

--- a/errors.go
+++ b/errors.go
@@ -2,7 +2,6 @@ package sqlds
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
@@ -22,8 +21,6 @@ var (
 	ErrorRowValidation = errors.New("SQL rows validation failed")
 	// ErrorConnectionClosed is returned when the database connection is unexpectedly closed
 	ErrorConnectionClosed = errors.New("database connection closed")
-	// ErrorPGXLifecycle is returned for PGX v5 specific connection lifecycle issues
-	ErrorPGXLifecycle = errors.New("PGX connection lifecycle error")
 )
 
 func ErrorSource(err error) backend.ErrorSource {
@@ -31,58 +28,4 @@ func ErrorSource(err error) backend.ErrorSource {
 		return backend.ErrorSourceDownstream
 	}
 	return backend.ErrorSourcePlugin
-}
-
-// IsPGXConnectionError checks if an error is related to PGX v5 connection issues
-func IsPGXConnectionError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	errStr := strings.ToLower(err.Error())
-	pgxConnectionErrors := []string{
-		"connection closed",
-		"connection reset",
-		"connection refused",
-		"broken pipe",
-		"eof",
-		"context canceled",
-		"context deadline exceeded",
-		"pgconn",
-		"conn is closed",
-		"bad connection",
-	}
-
-	for _, pgxErr := range pgxConnectionErrors {
-		if strings.Contains(errStr, pgxErr) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// ClassifyError determines the appropriate error source and type for SQL errors
-func ClassifyError(err error) (backend.ErrorSource, error) {
-	if err == nil {
-		return backend.ErrorSourcePlugin, nil
-	}
-
-	// Check for PGX v5 specific connection errors
-	if IsPGXConnectionError(err) {
-		// These are typically downstream connection issues
-		return backend.ErrorSourceDownstream, ErrorPGXLifecycle
-	}
-
-	// Check for row validation errors
-	if errors.Is(err, ErrorRowValidation) {
-		return backend.ErrorSourceDownstream, err
-	}
-
-	// Default to existing logic
-	if backend.IsDownstreamError(err) {
-		return backend.ErrorSourceDownstream, err
-	}
-
-	return backend.ErrorSourcePlugin, err
 }

--- a/query.go
+++ b/query.go
@@ -74,55 +74,40 @@ func NewQuery(db Connection, settings backend.DataSourceInstanceSettings, conver
 }
 
 // Run sends the query to the connection and converts the rows to a dataframe.
-func (q *DBQuery) Run(ctx context.Context, query *Query, args ...interface{}) (data.Frames, error) {
+func (q *DBQuery) Run(ctx context.Context, query *Query, queryErrorMutator QueryErrorMutator, args ...interface{}) (data.Frames, error) {
 	start := time.Now()
 	rows, err := q.DB.QueryContext(ctx, query.RawSQL, args...)
 	if err != nil {
-		// Determine error source based on retry configuration and error type
-		errSource := backend.ErrorSourcePlugin
-		errType := ErrorQuery
+		// Wrap with ErrorQuery to enable retry logic in datasource
+		queryErr := fmt.Errorf("%w: %w", ErrorQuery, err)
+		errWithSource := backend.NewErrorWithSource(queryErr, backend.DefaultErrorSource)
 
 		if errors.Is(err, context.Canceled) {
-			errType = context.Canceled
-			errSource = backend.ErrorSourceDownstream
-		} else if IsPGXConnectionError(err) {
-			errType = ErrorPGXLifecycle
-			errSource = backend.ErrorSourceDownstream
-		} else {
-			// Use enhanced error classification for PGX v5
-			errSource, _ = ClassifyError(err)
+			errWithSource = backend.NewErrorWithSource(err, backend.ErrorSourceDownstream)
+		} else if queryErrorMutator != nil {
+			errWithSource = queryErrorMutator.MutateQueryError(queryErr)
 		}
 
-		var errWithSource error
-		if errSource == backend.ErrorSourceDownstream {
-			errWithSource = backend.DownstreamError(fmt.Errorf("%w: %s", errType, err.Error()))
-		} else {
-			errWithSource = backend.PluginError(fmt.Errorf("%w: %s", errType, err.Error()))
-		}
-
-		q.metrics.CollectDuration(Source(errSource), StatusError, time.Since(start).Seconds())
+		q.metrics.CollectDuration(Source(errWithSource.ErrorSource()), StatusError, time.Since(start).Seconds())
 		return sqlutil.ErrorFrameFromQuery(query), errWithSource
 	}
 	q.metrics.CollectDuration(SourceDownstream, StatusOK, time.Since(start).Seconds())
 
 	// Check for an error response
 	if err := rows.Err(); err != nil {
+		queryErr := fmt.Errorf("%w: %w", ErrorQuery, err)
+		errWithSource := backend.NewErrorWithSource(queryErr, backend.DefaultErrorSource)
 		if errors.Is(err, sql.ErrNoRows) {
 			// Should we even response with an error here?
 			// The panel will simply show "no data"
-			errWithSource := backend.DownstreamError(fmt.Errorf("%s: %w", "No results from query", err))
+			errWithSource = backend.NewErrorWithSource(fmt.Errorf("%w: %s", err, "Error response from database"), backend.ErrorSourceDownstream)
 			return sqlutil.ErrorFrameFromQuery(query), errWithSource
 		}
-
-		errSource, _ := ClassifyError(err)
-		var errWithSource error
-		if errSource == backend.ErrorSourceDownstream {
-			errWithSource = backend.DownstreamError(fmt.Errorf("%s: %w", "Error response from database", err))
-		} else {
-			errWithSource = backend.PluginError(fmt.Errorf("%s: %w", "Error response from database", err))
+		if queryErrorMutator != nil {
+			errWithSource = queryErrorMutator.MutateQueryError(queryErr)
 		}
 
-		q.metrics.CollectDuration(Source(errSource), StatusError, time.Since(start).Seconds())
+		q.metrics.CollectDuration(Source(errWithSource.ErrorSource()), StatusError, time.Since(start).Seconds())
 		return sqlutil.ErrorFrameFromQuery(query), errWithSource
 	}
 
@@ -132,23 +117,34 @@ func (q *DBQuery) Run(ctx context.Context, query *Query, args ...interface{}) (d
 		}
 	}()
 
-	start = time.Now()
-	// Convert the response to frames
+	return q.convertRowsToFrames(rows, query, queryErrorMutator)
+}
+
+func (q *DBQuery) convertRowsToFrames(rows *sql.Rows, query *Query, queryErrorMutator QueryErrorMutator) (data.Frames, error) {
+	source := SourcePlugin
+	status := StatusOK
+	start := time.Now()
+	defer func() {
+		q.metrics.CollectDuration(source, status, time.Since(start).Seconds())
+	}()
+
 	res, err := getFrames(rows, q.rowLimit, q.converters, q.fillMode, query)
 	if err != nil {
-		errSource, _ := ClassifyError(err)
+		status = StatusError
 
 		// Additional checks for processing errors
-		if backend.IsDownstreamHTTPError(err) || isProcessingDownstreamError(err) {
-			errSource = backend.ErrorSourceDownstream
+		if backend.IsDownstreamHTTPError(err) {
+			source = SourceDownstream
+		} else if queryErrorMutator != nil {
+			errWithSource := queryErrorMutator.MutateQueryError(err)
+			source = Source(errWithSource.ErrorSource())
 		}
 
-		errWithSource := backend.NewErrorWithSource(fmt.Errorf("%w: %s", err, "Could not process SQL results"), errSource)
-		q.metrics.CollectDuration(Source(errSource), StatusError, time.Since(start).Seconds())
-		return sqlutil.ErrorFrameFromQuery(query), errWithSource
+		return sqlutil.ErrorFrameFromQuery(query), backend.NewErrorWithSource(
+			fmt.Errorf("%w: %s", err, "Could not process SQL results"),
+			backend.ErrorSource(source),
+		)
 	}
-
-	q.metrics.CollectDuration(SourcePlugin, StatusOK, time.Since(start).Seconds())
 	return res, nil
 }
 
@@ -305,27 +301,4 @@ func applyHeaders(query *Query, headers http.Header) *Query {
 	query.ConnectionArgs = raw
 
 	return query
-}
-
-func isProcessingDownstreamError(err error) bool {
-	downstreamErrors := []error{
-		data.ErrorInputFieldsWithoutRows,
-		data.ErrorSeriesUnsorted,
-		data.ErrorNullTimeValues,
-		ErrorRowValidation,
-		ErrorConnectionClosed,
-		ErrorPGXLifecycle,
-	}
-	for _, e := range downstreamErrors {
-		if errors.Is(err, e) {
-			return true
-		}
-	}
-
-	// Check for PGX connection errors
-	if IsPGXConnectionError(err) {
-		return true
-	}
-
-	return false
 }

--- a/query_integration_test.go
+++ b/query_integration_test.go
@@ -80,7 +80,7 @@ func TestQuery_MySQL(t *testing.T) {
 		}
 
 		sqlQuery := NewQuery(db, settings, []sqlutil.Converter{}, nil, defaultRowLimit)
-		_, err := sqlQuery.Run(ctx, q)
+		_, err := sqlQuery.Run(ctx, q, nil)
 		if err == nil {
 			t.Fatal("expected an error but received none")
 		}

--- a/query_test.go
+++ b/query_test.go
@@ -242,12 +242,6 @@ func TestNewQuery(t *testing.T) {
 	require.NotNil(t, dbQuery.metrics)
 }
 
-func TestRun_RowsError(t *testing.T) {
-	// Note: This test would require a mock that returns valid rows but with an error
-	// This is difficult to test without a proper mock framework for sql.Rows
-	t.Skip("Requires advanced mocking of sql.Rows")
-}
-
 func TestRun_WithDownStreamErrorMutator(t *testing.T) {
 	ctx := context.Background()
 	conn := &testConnection{

--- a/query_test.go
+++ b/query_test.go
@@ -85,7 +85,7 @@ func TestQuery_Timeout(t *testing.T) {
 		}
 
 		sqlQuery := NewQuery(conn, settings, []sqlutil.Converter{}, nil, defaultRowLimit)
-		_, err := sqlQuery.Run(ctx, &Query{})
+		_, err := sqlQuery.Run(ctx, &Query{}, nil)
 
 		if !errors.Is(err, context.Canceled) {
 			t.Fatal("expected error to be context.Canceled, received", err)
@@ -112,9 +112,9 @@ func TestQuery_Timeout(t *testing.T) {
 		}
 
 		sqlQuery := NewQuery(conn, settings, []sqlutil.Converter{}, nil, defaultRowLimit)
-		_, err := sqlQuery.Run(ctx, &Query{})
+		_, err := sqlQuery.Run(ctx, &Query{}, nil)
 
-		if !errors.Is(err, ErrorQuery) {
+		if !errors.Is(err, errorQueryCompleted) {
 			t.Fatal("expected function to complete, received error: ", err)
 		}
 	})
@@ -189,111 +189,101 @@ func TestLabelNameSanitization(t *testing.T) {
 	}
 }
 
-func TestIsProcessingDownstreamError(t *testing.T) {
-	tests := []struct {
-		name     string
-		err      error
-		expected bool
-	}{
-		{
-			name:     "ErrorInputFieldsWithoutRows returns true",
-			err:      data.ErrorInputFieldsWithoutRows,
-			expected: true,
-		},
-		{
-			name:     "ErrorSeriesUnsorted returns true",
-			err:      data.ErrorSeriesUnsorted,
-			expected: true,
-		},
-		{
-			name:     "ErrorNullTimeValues returns true",
-			err:      data.ErrorNullTimeValues,
-			expected: true,
-		},
-		{
-			name:     "Different error returns false",
-			err:      errors.New("some other error"),
-			expected: false,
-		},
-		{
-			name:     "Wrapped downstream error returns true",
-			err:      fmt.Errorf("wrapped: %w", data.ErrorInputFieldsWithoutRows),
-			expected: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := isProcessingDownstreamError(tt.err)
-			if result != tt.expected {
-				t.Errorf("isProcessingDownstreamError(%v) = %v; want %v", tt.err, result, tt.expected)
-			}
-		})
-	}
+func TestValidateRows(t *testing.T) {
+	t.Run("returns error for nil rows", func(t *testing.T) {
+		err := validateRows(nil)
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrorRowValidation)
+		require.Contains(t, err.Error(), "rows is nil")
+	})
 }
 
-func TestPGXErrorClassification(t *testing.T) {
-	tests := []struct {
-		name           string
-		errorMsg       string
-		expectedSource backend.ErrorSource
-		expectedIsPGX  bool
-	}{
-		{
-			name:           "nil pointer dereference",
-			errorMsg:       "runtime error: invalid memory address or nil pointer dereference",
-			expectedSource: backend.ErrorSourcePlugin,
-			expectedIsPGX:  false,
-		},
-		{
-			name:           "connection closed",
-			errorMsg:       "connection closed",
-			expectedSource: backend.ErrorSourceDownstream,
-			expectedIsPGX:  true,
-		},
-		{
-			name:           "broken pipe",
-			errorMsg:       "broken pipe",
-			expectedSource: backend.ErrorSourceDownstream,
-			expectedIsPGX:  true,
-		},
-		{
-			name:           "pgconn error",
-			errorMsg:       "pgconn: connection failed",
-			expectedSource: backend.ErrorSourceDownstream,
-			expectedIsPGX:  true,
-		},
-		{
-			name:           "regular SQL error",
-			errorMsg:       "syntax error at position 1",
-			expectedSource: backend.ErrorSourcePlugin,
-			expectedIsPGX:  false,
-		},
+func TestFixFrameForLongToMulti_NilFrame(t *testing.T) {
+	err := fixFrameForLongToMulti(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "can not convert to wide series, input is nil")
+}
+
+func TestFixFrameForLongToMulti_NonNullableTime(t *testing.T) {
+	time1 := time.UnixMilli(1)
+	time2 := time.UnixMilli(2)
+	frame := data.NewFrame("",
+		data.NewField("time", nil, []time.Time{time1, time2}),
+		data.NewField("host", nil, []string{"a", "b"}),
+		data.NewField("value", nil, []float64{1, 2}),
+	)
+
+	err := fixFrameForLongToMulti(frame)
+	require.NoError(t, err)
+
+	// Verify the frame wasn't modified since time was already non-nullable
+	require.Equal(t, data.FieldTypeTime, frame.Fields[0].Type())
+	require.Equal(t, 2, frame.Fields[0].Len())
+}
+
+func TestNewQuery(t *testing.T) {
+	conn := &testConnection{}
+	settings := backend.DataSourceInstanceSettings{
+		Name: "test-datasource",
+		Type: "test-type",
+	}
+	converters := []sqlutil.Converter{}
+	fillMode := &data.FillMissing{}
+	rowLimit := int64(1000)
+
+	dbQuery := NewQuery(conn, settings, converters, fillMode, rowLimit)
+
+	require.NotNil(t, dbQuery)
+	require.Equal(t, conn, dbQuery.DB)
+	require.Equal(t, "test-datasource", dbQuery.DSName)
+	require.Equal(t, converters, dbQuery.converters)
+	require.Equal(t, fillMode, dbQuery.fillMode)
+	require.Equal(t, rowLimit, dbQuery.rowLimit)
+	require.NotNil(t, dbQuery.metrics)
+}
+
+func TestRun_RowsError(t *testing.T) {
+	// Note: This test would require a mock that returns valid rows but with an error
+	// This is difficult to test without a proper mock framework for sql.Rows
+	t.Skip("Requires advanced mocking of sql.Rows")
+}
+
+func TestRun_WithDownStreamErrorMutator(t *testing.T) {
+	ctx := context.Background()
+	conn := &testConnection{
+		QueryWait: 0,
+	}
+	settings := backend.DataSourceInstanceSettings{
+		Name: "test",
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := errors.New(tt.errorMsg)
-
-			// Test IsPGXConnectionError
-			isPGX := IsPGXConnectionError(err)
-			if isPGX != tt.expectedIsPGX {
-				t.Errorf("IsPGXConnectionError() = %v, expected %v", isPGX, tt.expectedIsPGX)
-			}
-
-			// Test ClassifyError
-			source, _ := ClassifyError(err)
-			if source != tt.expectedSource {
-				t.Errorf("ClassifyError() source = %v, expected %v", source, tt.expectedSource)
-			}
-
-			// Test isProcessingDownstreamError
-			if tt.expectedSource == backend.ErrorSourceDownstream {
-				isDownstream := isProcessingDownstreamError(err)
-				if !isDownstream {
-					t.Errorf("isProcessingDownstreamError() = %v, expected true for downstream error", isDownstream)
-				}
-			}
-		})
+	query := &Query{
+		RawSQL: "SELECT * FROM test",
+		RefID:  "A",
 	}
+
+	// Create a mock ErrorMutator
+	mockMutator := &mockErrorMutator{
+		shouldMutate: true,
+	}
+
+	dbQuery := NewQuery(conn, settings, []sqlutil.Converter{}, nil, defaultRowLimit)
+	_, err := dbQuery.Run(ctx, query, mockMutator)
+
+	require.Error(t, err)
+	require.True(t, mockMutator.called, "ErrorMutator should have been called")
+}
+
+// mockErrorMutator is a simple implementation for testing
+type mockErrorMutator struct {
+	shouldMutate bool
+	called       bool
+}
+
+func (m *mockErrorMutator) MutateQueryError(err error) backend.ErrorWithSource {
+	m.called = true
+	if m.shouldMutate {
+		return backend.NewErrorWithSource(err, backend.ErrorSourceDownstream)
+	}
+	return backend.NewErrorWithSource(err, backend.ErrorSourcePlugin)
 }


### PR DESCRIPTION
 Refactor error handling to use driver-controlled QueryErrorMutator interface. This was brought about because downstream errors are being counted as plugin errors for CH. Read more on Slack [here](https://raintank-corp.slack.com/archives/C03MW34JP0U/p1758633719397579)

When reviewing, please check that this doesn't break retry logic and error classification for your sqlds data sources.

- Added QueryErrorMutator interface - New optional interface drivers can implement to customize error source classification
- Removed PGX v5/PostgreSQL-specific error detection. This error detection should be added to the Cockroach repo.
