### PR TITLE
feat: emit response-size histograms from DBQuery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/grafana/grafana-plugin-sdk-go v0.290.1
 	github.com/mithrandie/csvq-driver v1.7.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -84,7 +85,6 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pierrec/lz4/v4 v4.1.23 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/metrics.go
+++ b/metrics.go
@@ -3,6 +3,7 @@ package sqlds
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/prometheus/client_golang/prometheus"
@@ -34,6 +35,26 @@ var durationMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Help:      "Duration of plugin execution",
 }, []string{"datasource_name", "datasource_type", "source", "endpoint", "status"})
 
+var responseRowsMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace:                       "plugins",
+	Name:                            "sql_response_rows",
+	Help:                            "Number of rows returned by a SQL datasource query",
+	Buckets:                         []float64{1, 10, 100, 1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000},
+	NativeHistogramBucketFactor:     1.1,
+	NativeHistogramMaxBucketNumber:  100,
+	NativeHistogramMinResetDuration: time.Hour,
+}, []string{"datasource_type"})
+
+var responseCellsMetric = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace:                       "plugins",
+	Name:                            "sql_response_cells",
+	Help:                            "Number of cells (rows × fields) returned by a SQL datasource query",
+	Buckets:                         []float64{1, 100, 10_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000, 10_000_000_000},
+	NativeHistogramBucketFactor:     1.1,
+	NativeHistogramMaxBucketNumber:  100,
+	NativeHistogramMinResetDuration: time.Hour,
+}, []string{"datasource_type"})
+
 func NewMetrics(dsName, dsType string, endpoint Endpoint) Metrics {
 	dsName, ok := sanitizeLabelName(dsName)
 	if !ok {
@@ -48,6 +69,11 @@ func (m *Metrics) WithEndpoint(endpoint Endpoint) Metrics {
 
 func (m *Metrics) CollectDuration(source Source, status Status, duration float64) {
 	durationMetric.WithLabelValues(m.DSName, m.DSType, string(source), string(m.Endpoint), string(status)).Observe(duration)
+}
+
+func (m *Metrics) CollectResponseSize(rows, cells int64) {
+	responseRowsMetric.WithLabelValues(m.DSType).Observe(float64(rows))
+	responseCellsMetric.WithLabelValues(m.DSType).Observe(float64(cells))
 }
 
 // sanitizeLabelName removes all invalid chars from the label name.

--- a/query.go
+++ b/query.go
@@ -156,7 +156,30 @@ func (q *DBQuery) convertRowsToFrames(rows *sql.Rows, query *Query, queryErrorMu
 			backend.ErrorSource(source),
 		)
 	}
+
+	q.observeResponseSize(res)
+
 	return res, nil
+}
+
+// observeResponseSize records rows + cells (rows × fields) across all returned frames.
+// Skips emission entirely if any frame has inconsistent field lengths, since partial
+// totals would mislead operators investigating large responses.
+func (q *DBQuery) observeResponseSize(frames data.Frames) {
+	var totalRows, totalCells int64
+	for _, frame := range frames {
+		if frame == nil {
+			continue
+		}
+		rowLen, err := frame.RowLen()
+		if err != nil {
+			backend.Logger.Debug("skipping response size observation", "error", err.Error())
+			return
+		}
+		totalRows += int64(rowLen)
+		totalCells += int64(rowLen) * int64(len(frame.Fields))
+	}
+	q.metrics.CollectResponseSize(totalRows, totalCells)
 }
 
 // getFrames converts rows to dataframes

--- a/query_test.go
+++ b/query_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -349,6 +351,64 @@ func TestRun_ErrorQueryWrapping(t *testing.T) {
 		require.True(t, errors.Is(receivedErr, ErrorQuery), "Mutator should receive ErrorQuery-wrapped error")
 		require.True(t, errors.Is(receivedErr, errorQueryCompleted), "Original error should be in chain")
 	})
+}
+
+func TestCollectResponseSize(t *testing.T) {
+	// Use a unique datasource_type label so this test does not race with
+	// observations from other tests against the same global histogram vec.
+	const dsType = "TestCollectResponseSize-type"
+
+	m := NewMetrics("test-ds", dsType, EndpointQuery)
+	m.CollectResponseSize(42, 168)
+
+	rows := histogramSnapshot(t, responseRowsMetric, dsType)
+	require.Equal(t, uint64(1), rows.GetSampleCount(), "rows histogram should record one observation")
+	require.Equal(t, 42.0, rows.GetSampleSum(), "rows histogram sum should equal observed value")
+
+	cells := histogramSnapshot(t, responseCellsMetric, dsType)
+	require.Equal(t, uint64(1), cells.GetSampleCount(), "cells histogram should record one observation")
+	require.Equal(t, 168.0, cells.GetSampleSum(), "cells histogram sum should equal observed value")
+}
+
+func TestObserveResponseSize_MultipleFrames(t *testing.T) {
+	const dsType = "TestObserveResponseSize-type"
+
+	frames := data.Frames{
+		data.NewFrame("a",
+			data.NewField("t", nil, []time.Time{time.UnixMilli(1), time.UnixMilli(2)}),
+			data.NewField("v", nil, []float64{1, 2}),
+		),
+		data.NewFrame("b",
+			data.NewField("t", nil, []time.Time{time.UnixMilli(3)}),
+			data.NewField("v", nil, []float64{3}),
+			data.NewField("w", nil, []float64{4}),
+		),
+	}
+
+	q := &DBQuery{metrics: NewMetrics("test-ds", dsType, EndpointQuery)}
+	q.observeResponseSize(frames)
+
+	rows := histogramSnapshot(t, responseRowsMetric, dsType)
+	require.Equal(t, uint64(1), rows.GetSampleCount())
+	require.Equal(t, 3.0, rows.GetSampleSum(), "should sum rows across frames (2 + 1)")
+
+	cells := histogramSnapshot(t, responseCellsMetric, dsType)
+	require.Equal(t, uint64(1), cells.GetSampleCount())
+	require.Equal(t, 7.0, cells.GetSampleSum(), "should sum cells: 2*2 + 1*3 = 7")
+}
+
+// histogramSnapshot extracts the dto.Histogram for a given label value, so tests
+// can assert on sample count and sum directly.
+func histogramSnapshot(t *testing.T, vec *prometheus.HistogramVec, dsType string) *dto.Histogram {
+	t.Helper()
+	obs, err := vec.GetMetricWithLabelValues(dsType)
+	require.NoError(t, err)
+	hist, ok := obs.(prometheus.Histogram)
+	require.True(t, ok, "expected prometheus.Histogram")
+	out := &dto.Metric{}
+	require.NoError(t, hist.Write(out))
+	require.NotNil(t, out.Histogram)
+	return out.Histogram
 }
 
 // mockErrorMutator is a simple implementation for testing


### PR DESCRIPTION
## Summary
- Adds two Prometheus histograms — `plugins_sql_response_rows` and `plugins_sql_response_cells` — labelled by `datasource_type` only, matching the SDK's native-histogram settings (factor 1.1, max 100 buckets, 1h reset).
- Emits both from `DBQuery.convertRowsToFrames` after successful frame conversion, so the observation reflects post-conversion shape (including the `LongToMulti` multi-frame case).
- Skips emission entirely on `RowLen` error to avoid misleading partial totals.

## Why
This PR is step one of a broader measurement plan (tracked in grafana/data-sources#288) — giving us an aggregate trend of query payload sizes across the SQL datasource fleet. Subsequent PRs land in `grafana-plugin-sdk-go` (structured log on threshold crossing, threshold-gated counter, gRPC-path bytes coverage for native-driver plugins).

Cardinality is deliberately constrained to `datasource_type` only; the per-instance dimension is added downstream in the counter PR where it's self-limited by threshold gating.