### PR TITLE
feat(responseobs): add subpackage for large-response observation

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -311,7 +311,8 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 	//    Because the datasource driver does not include an option for permanent connections, we retry the connection
 	//    if the query fails. NOTE: this does not include some errors like "ErrNoRows"
 	dbQuery := NewQuery(dbConn.db, dbConn.settings, ds.cachedConverters, fillMode, ds.rowLimit).
-		WithRowCapacityHint(ds.rowCapacityHint)
+		WithRowCapacityHint(ds.rowCapacityHint).
+		WithResponseThresholds(ds.DriverSettings().ResponseThresholds)
 	res, err := dbQuery.Run(ctx, q, queryErrorMutator, args...)
 	if err == nil {
 		return res, nil
@@ -338,7 +339,8 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 				}
 
 				dbQuery := NewQuery(db, dbConn.settings, ds.cachedConverters, fillMode, ds.rowLimit).
-					WithRowCapacityHint(ds.rowCapacityHint)
+					WithRowCapacityHint(ds.rowCapacityHint).
+					WithResponseThresholds(ds.DriverSettings().ResponseThresholds)
 				res, err = dbQuery.Run(ctx, q, queryErrorMutator, args...)
 				if err == nil {
 					return res, err

--- a/driver.go
+++ b/driver.go
@@ -10,6 +10,8 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+
+	"github.com/grafana/sqlds/v5/responseobs"
 )
 
 type DriverSettings struct {
@@ -28,6 +30,12 @@ type DriverSettings struct {
 	// patterns, statements with a hard LIMIT) should set this to avoid
 	// per-column slice growth during FrameFromRows.
 	RowCapacityHint int64
+	// ResponseThresholds configures when a query response is considered
+	// "large" enough to emit a structured warn log. A zero value on
+	// either field disables that dimension. At the sqlds layer bytes
+	// cannot be measured cheaply, so only the Rows threshold takes
+	// effect for sqlds-emitted observations.
+	ResponseThresholds responseobs.Thresholds
 }
 
 // Driver is a simple interface that defines how to connect to a backend SQL datasource

--- a/query.go
+++ b/query.go
@@ -16,6 +16,8 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+
+	"github.com/grafana/sqlds/v5/responseobs"
 )
 
 // FormatQueryOption defines how the user has chosen to represent the data
@@ -62,12 +64,14 @@ type DBQuery struct {
 	converters      []sqlutil.Converter
 	rowLimit        int64
 	rowCapacityHint int64
+	thresholds      responseobs.Thresholds
 }
 
 func NewQuery(db Connection, settings backend.DataSourceInstanceSettings, converters []sqlutil.Converter, fillMode *data.FillMissing, rowLimit int64) *DBQuery {
 	return &DBQuery{
 		DB:         db,
 		DSName:     settings.Name,
+		Settings:   settings,
 		converters: converters,
 		fillMode:   fillMode,
 		metrics:    NewMetrics(settings.Name, settings.Type, EndpointQuery),
@@ -81,6 +85,15 @@ func NewQuery(db Connection, settings backend.DataSourceInstanceSettings, conver
 // chaining after NewQuery.
 func (q *DBQuery) WithRowCapacityHint(hint int64) *DBQuery {
 	q.rowCapacityHint = hint
+	return q
+}
+
+// WithResponseThresholds configures when a query response is considered
+// "large" enough to emit a structured warn log. Zero fields on the
+// Thresholds value disable that dimension. Returns the receiver to allow
+// chaining after NewQuery.
+func (q *DBQuery) WithResponseThresholds(t responseobs.Thresholds) *DBQuery {
+	q.thresholds = t
 	return q
 }
 
@@ -139,10 +152,10 @@ func (q *DBQuery) Run(ctx context.Context, query *Query, queryErrorMutator Query
 		}
 	}()
 
-	return q.convertRowsToFrames(rows, query, queryErrorMutator)
+	return q.convertRowsToFrames(ctx, rows, query, queryErrorMutator, start)
 }
 
-func (q *DBQuery) convertRowsToFrames(rows *sql.Rows, query *Query, queryErrorMutator QueryErrorMutator) (data.Frames, error) {
+func (q *DBQuery) convertRowsToFrames(ctx context.Context, rows *sql.Rows, query *Query, queryErrorMutator QueryErrorMutator, runStart time.Time) (data.Frames, error) {
 	source := SourcePlugin
 	status := StatusOK
 	start := time.Now()
@@ -168,15 +181,17 @@ func (q *DBQuery) convertRowsToFrames(rows *sql.Rows, query *Query, queryErrorMu
 		)
 	}
 
-	q.observeResponseSize(res)
+	q.observeResponseSize(ctx, res, query.RefID, runStart)
 
 	return res, nil
 }
 
-// observeResponseSize records rows + cells (rows × fields) across all returned frames.
-// Skips emission entirely if any frame has inconsistent field lengths, since partial
-// totals would mislead operators investigating large responses.
-func (q *DBQuery) observeResponseSize(frames data.Frames) {
+// observeResponseSize records rows + cells (rows × fields) across all returned frames
+// and, if thresholds are configured, hands the observation to responseobs for
+// structured large-response logging. Skips emission entirely if any frame has
+// inconsistent field lengths, since partial totals would mislead operators
+// investigating large responses.
+func (q *DBQuery) observeResponseSize(ctx context.Context, frames data.Frames, refID string, runStart time.Time) {
 	var totalRows, totalCells int64
 	for _, frame := range frames {
 		if frame == nil {
@@ -191,6 +206,14 @@ func (q *DBQuery) observeResponseSize(frames data.Frames) {
 		totalCells += int64(rowLen) * int64(len(frame.Fields))
 	}
 	q.metrics.CollectResponseSize(totalRows, totalCells)
+
+	responseobs.Observe(ctx, responseobs.Observation{
+		Datasource: q.Settings,
+		Rows:       totalRows,
+		Cells:      totalCells,
+		Duration:   time.Since(runStart),
+		RefID:      refID,
+	}, q.thresholds)
 }
 
 // getFrames converts rows to dataframes.

--- a/query_test.go
+++ b/query_test.go
@@ -5,16 +5,20 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/sqlds/v5/responseobs"
 )
 
 var (
@@ -410,7 +414,7 @@ func TestObserveResponseSize_MultipleFrames(t *testing.T) {
 	}
 
 	q := &DBQuery{metrics: NewMetrics("test-ds", dsType, EndpointQuery)}
-	q.observeResponseSize(frames)
+	q.observeResponseSize(context.Background(), frames, "A", time.Now())
 
 	rows := histogramSnapshot(t, responseRowsMetric, dsType)
 	require.Equal(t, uint64(1), rows.GetSampleCount())
@@ -419,6 +423,86 @@ func TestObserveResponseSize_MultipleFrames(t *testing.T) {
 	cells := histogramSnapshot(t, responseCellsMetric, dsType)
 	require.Equal(t, uint64(1), cells.GetSampleCount())
 	require.Equal(t, 7.0, cells.GetSampleSum(), "should sum cells: 2*2 + 1*3 = 7")
+}
+
+func TestObserveResponseSize_ThresholdCrossed_EmitsLog(t *testing.T) {
+	rec := swapBackendLogger(t)
+
+	frame := data.NewFrame("big",
+		data.NewField("v", nil, []int64{1, 2, 3, 4, 5}),
+	)
+	q := &DBQuery{
+		Settings:   backend.DataSourceInstanceSettings{Type: "mssql", UID: "uid1", Name: "ds1"},
+		metrics:    NewMetrics("ds1", "TestObserveResponseSize-cross", EndpointQuery),
+		thresholds: responseobs.Thresholds{Rows: 3},
+	}
+	q.observeResponseSize(context.Background(), data.Frames{frame}, "A", time.Now())
+
+	require.Len(t, rec.entries, 1, "expected one large-response log")
+	assert.Equal(t, "large datasource response", rec.entries[0].msg)
+}
+
+func TestObserveResponseSize_ThresholdNotCrossed_NoLog(t *testing.T) {
+	rec := swapBackendLogger(t)
+
+	frame := data.NewFrame("small",
+		data.NewField("v", nil, []int64{1, 2}),
+	)
+	q := &DBQuery{
+		Settings:   backend.DataSourceInstanceSettings{Type: "mssql", UID: "uid1", Name: "ds1"},
+		metrics:    NewMetrics("ds1", "TestObserveResponseSize-nocross", EndpointQuery),
+		thresholds: responseobs.Thresholds{Rows: 100},
+	}
+	q.observeResponseSize(context.Background(), data.Frames{frame}, "A", time.Now())
+
+	assert.Empty(t, rec.entries, "no log expected below threshold")
+}
+
+// recordedLogEntry + recordingBackendLogger capture warn/error/etc calls on
+// backend.Logger so tests can assert side effects without relying on the
+// default hclog output. Not parallel-safe because backend.Logger is global.
+type recordedLogEntry struct {
+	level log.Level
+	msg   string
+	args  []interface{}
+}
+
+type recordingBackendLogger struct {
+	mu      sync.Mutex
+	entries []recordedLogEntry
+}
+
+func (l *recordingBackendLogger) record(level log.Level, msg string, args []interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, recordedLogEntry{level: level, msg: msg, args: args})
+}
+
+func (l *recordingBackendLogger) Debug(msg string, args ...interface{}) {
+	l.record(log.Debug, msg, args)
+}
+func (l *recordingBackendLogger) Info(msg string, args ...interface{}) {
+	l.record(log.Info, msg, args)
+}
+func (l *recordingBackendLogger) Warn(msg string, args ...interface{}) {
+	l.record(log.Warn, msg, args)
+}
+func (l *recordingBackendLogger) Error(msg string, args ...interface{}) {
+	l.record(log.Error, msg, args)
+}
+func (l *recordingBackendLogger) With(_ ...interface{}) log.Logger          { return l }
+func (l *recordingBackendLogger) Level() log.Level                          { return log.Debug }
+func (l *recordingBackendLogger) FromContext(_ context.Context) log.Logger  { return l }
+
+// swapBackendLogger replaces backend.Logger with a recording logger for the
+// lifetime of the test and restores it on cleanup.
+func swapBackendLogger(t *testing.T) *recordingBackendLogger {
+	t.Helper()
+	rec := &recordingBackendLogger{}
+	orig := backend.Logger
+	backend.Logger = rec
+	t.Cleanup(func() { backend.Logger = orig })
+	return rec
 }
 
 // histogramSnapshot extracts the dto.Histogram for a given label value, so tests

--- a/responseobs/counter.go
+++ b/responseobs/counter.go
@@ -1,0 +1,22 @@
+package responseobs
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// largeResponsesCounter increments once per Observation that crosses a
+// configured threshold. Cardinality is self-limiting because the counter
+// only increments on threshold crossings — the number of active series is
+// bounded by the number of datasource instances actually producing large
+// responses, not by total query volume.
+//
+// The app_url label carries the stack identifier. It replaces the earlier
+// "slug" label in the plan because backend.GrafanaConfig exposes no
+// dedicated slug accessor; downstream operators can derive a slug by
+// parsing the URL if needed.
+var largeResponsesCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "plugins",
+	Name:      "sql_large_responses_total",
+	Help:      "Number of SQL datasource responses that crossed a configured size threshold (rows or bytes).",
+}, []string{"datasource_type", "app_url", "datasource_uid"})

--- a/responseobs/responseobs.go
+++ b/responseobs/responseobs.go
@@ -56,15 +56,17 @@ type Observation struct {
 }
 
 // Observe compares obs against t. If a threshold is crossed, it emits a
-// single structured warn log via backend.Logger and returns true.
-// Otherwise it returns false and emits nothing. Intended to be called
-// at most once per response.
+// single structured warn log via backend.Logger, increments the
+// plugins_sql_large_responses_total counter, and returns true. Otherwise
+// it returns false and emits nothing. Intended to be called at most once
+// per response.
 func Observe(ctx context.Context, obs Observation, t Thresholds) bool {
 	if !crosses(obs, t) {
 		return false
 	}
+	appURL := appURLFromContext(ctx)
 	backend.Logger.Warn("large datasource response",
-		"app_url", appURLFromContext(ctx),
+		"app_url", appURL,
 		"datasource_type", obs.Datasource.Type,
 		"datasource_uid", obs.Datasource.UID,
 		"datasource_name", obs.Datasource.Name,
@@ -75,6 +77,7 @@ func Observe(ctx context.Context, obs Observation, t Thresholds) bool {
 		"ref_id", obs.RefID,
 		"query_hash", obs.QueryHash,
 	)
+	largeResponsesCounter.WithLabelValues(obs.Datasource.Type, appURL, obs.Datasource.UID).Inc()
 	return true
 }
 

--- a/responseobs/responseobs.go
+++ b/responseobs/responseobs.go
@@ -1,0 +1,104 @@
+// Package responseobs observes SQL datasource response sizes and emits a
+// structured warn log when a response crosses a configured threshold.
+//
+// The package is intentionally narrow: callers compute response shape
+// (rows, cells, optionally bytes) and a single Observe call handles
+// threshold evaluation and log emission. The return value signals whether
+// a threshold was crossed, so downstream consumers (e.g. a large-response
+// counter) can piggyback on the same decision point.
+//
+// Thresholds default to values appropriate for datasource plugins at
+// Grafana's managed-tenant scale; plugins with known-large responses can
+// override per-instance via sqlds.DriverSettings.
+package responseobs
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+const (
+	// DefaultBytesThreshold is 50 MiB.
+	DefaultBytesThreshold int64 = 50 * 1024 * 1024
+	// DefaultRowsThreshold is one million rows.
+	DefaultRowsThreshold int64 = 1_000_000
+)
+
+// Thresholds configures what counts as a "large" response. A zero on
+// either field disables that dimension — useful at measurement layers
+// where one of the two values is unavailable (e.g. sqlds can count rows
+// but not serialized bytes).
+type Thresholds struct {
+	Bytes int64
+	Rows  int64
+}
+
+// Defaults returns Thresholds populated with DefaultBytesThreshold and
+// DefaultRowsThreshold.
+func Defaults() Thresholds {
+	return Thresholds{Bytes: DefaultBytesThreshold, Rows: DefaultRowsThreshold}
+}
+
+// Observation is what callers hand to Observe. Fields that the calling
+// layer cannot measure should be left zero; Observe treats zero as
+// "not measured" for threshold comparison purposes.
+type Observation struct {
+	Datasource backend.DataSourceInstanceSettings
+	Bytes      int64
+	Rows       int64
+	Cells      int64
+	Duration   time.Duration
+	RefID      string
+	// QueryHash is optional. Empty string means not computed.
+	QueryHash string
+}
+
+// Observe compares obs against t. If a threshold is crossed, it emits a
+// single structured warn log via backend.Logger and returns true.
+// Otherwise it returns false and emits nothing. Intended to be called
+// at most once per response.
+func Observe(ctx context.Context, obs Observation, t Thresholds) bool {
+	if !crosses(obs, t) {
+		return false
+	}
+	backend.Logger.Warn("large datasource response",
+		"app_url", appURLFromContext(ctx),
+		"datasource_type", obs.Datasource.Type,
+		"datasource_uid", obs.Datasource.UID,
+		"datasource_name", obs.Datasource.Name,
+		"bytes", obs.Bytes,
+		"rows", obs.Rows,
+		"cells", obs.Cells,
+		"duration_ms", obs.Duration.Milliseconds(),
+		"ref_id", obs.RefID,
+		"query_hash", obs.QueryHash,
+	)
+	return true
+}
+
+func crosses(obs Observation, t Thresholds) bool {
+	if t.Bytes > 0 && obs.Bytes >= t.Bytes {
+		return true
+	}
+	if t.Rows > 0 && obs.Rows >= t.Rows {
+		return true
+	}
+	return false
+}
+
+// appURLFromContext returns the Grafana app URL from plugin context when
+// available, else the empty string. OSS deployments may not populate it;
+// operators can derive a slug downstream by parsing the URL.
+func appURLFromContext(ctx context.Context) string {
+	cfg := backend.GrafanaConfigFromContext(ctx)
+	if cfg == nil {
+		return ""
+	}
+	url, err := cfg.AppURL()
+	if err != nil {
+		return ""
+	}
+	return url
+}

--- a/responseobs/responseobs_test.go
+++ b/responseobs/responseobs_test.go
@@ -1,0 +1,200 @@
+package responseobs
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCrosses(t *testing.T) {
+	cases := []struct {
+		name   string
+		obs    Observation
+		thresh Thresholds
+		want   bool
+	}{
+		{
+			name:   "neither crossed",
+			obs:    Observation{Bytes: 100, Rows: 100},
+			thresh: Thresholds{Bytes: 1000, Rows: 1000},
+			want:   false,
+		},
+		{
+			name:   "bytes crossed only",
+			obs:    Observation{Bytes: 2000, Rows: 100},
+			thresh: Thresholds{Bytes: 1000, Rows: 1000},
+			want:   true,
+		},
+		{
+			name:   "rows crossed only",
+			obs:    Observation{Bytes: 100, Rows: 2000},
+			thresh: Thresholds{Bytes: 1000, Rows: 1000},
+			want:   true,
+		},
+		{
+			name:   "both crossed",
+			obs:    Observation{Bytes: 2000, Rows: 2000},
+			thresh: Thresholds{Bytes: 1000, Rows: 1000},
+			want:   true,
+		},
+		{
+			name:   "bytes threshold disabled, rows crossed",
+			obs:    Observation{Bytes: 1 << 30, Rows: 2000},
+			thresh: Thresholds{Bytes: 0, Rows: 1000},
+			want:   true,
+		},
+		{
+			name:   "both thresholds disabled",
+			obs:    Observation{Bytes: 1 << 30, Rows: 1 << 20},
+			thresh: Thresholds{},
+			want:   false,
+		},
+		{
+			name:   "exactly at threshold crosses (>=)",
+			obs:    Observation{Rows: 1000},
+			thresh: Thresholds{Rows: 1000},
+			want:   true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, crosses(tc.obs, tc.thresh))
+		})
+	}
+}
+
+func TestDefaults(t *testing.T) {
+	d := Defaults()
+	assert.Equal(t, int64(50*1024*1024), d.Bytes)
+	assert.Equal(t, int64(1_000_000), d.Rows)
+}
+
+func TestObserve_NoCross_SilentReturnsFalse(t *testing.T) {
+	rec := swapLogger(t)
+
+	ok := Observe(context.Background(),
+		Observation{Rows: 10},
+		Thresholds{Rows: 100})
+
+	assert.False(t, ok)
+	assert.Empty(t, rec.entries, "no log expected below threshold")
+}
+
+func TestObserve_Cross_LogsAndReturnsTrue(t *testing.T) {
+	rec := swapLogger(t)
+
+	obs := Observation{
+		Datasource: backend.DataSourceInstanceSettings{
+			Type: "mssql",
+			UID:  "abc123",
+			Name: "my-sql",
+		},
+		Rows:     2_000_000,
+		Cells:    10_000_000,
+		Duration: 2500 * time.Millisecond,
+		RefID:    "A",
+	}
+	ok := Observe(context.Background(), obs, Thresholds{Rows: DefaultRowsThreshold})
+
+	require.True(t, ok)
+	require.Len(t, rec.entries, 1)
+	e := rec.entries[0]
+	assert.Equal(t, log.Warn, e.level)
+	assert.Equal(t, "large datasource response", e.msg)
+	fields := e.kv()
+	assert.Equal(t, "mssql", fields["datasource_type"])
+	assert.Equal(t, "abc123", fields["datasource_uid"])
+	assert.Equal(t, "my-sql", fields["datasource_name"])
+	assert.Equal(t, int64(2_000_000), fields["rows"])
+	assert.Equal(t, int64(10_000_000), fields["cells"])
+	assert.Equal(t, int64(2500), fields["duration_ms"])
+	assert.Equal(t, "A", fields["ref_id"])
+}
+
+func TestObserve_AppURLFromContext(t *testing.T) {
+	rec := swapLogger(t)
+
+	cfg := backend.NewGrafanaCfg(map[string]string{
+		backend.AppURL: "https://example.grafana.net/",
+	})
+	ctx := backend.WithGrafanaConfig(context.Background(), cfg)
+
+	ok := Observe(ctx,
+		Observation{Rows: DefaultRowsThreshold},
+		Thresholds{Rows: DefaultRowsThreshold})
+
+	require.True(t, ok)
+	require.Len(t, rec.entries, 1)
+	assert.Equal(t, "https://example.grafana.net/", rec.entries[0].kv()["app_url"])
+}
+
+func TestObserve_AppURLAbsent_EmptyField(t *testing.T) {
+	rec := swapLogger(t)
+
+	ok := Observe(context.Background(),
+		Observation{Rows: DefaultRowsThreshold},
+		Thresholds{Rows: DefaultRowsThreshold})
+
+	require.True(t, ok)
+	require.Len(t, rec.entries, 1)
+	assert.Equal(t, "", rec.entries[0].kv()["app_url"])
+}
+
+// swapLogger replaces backend.Logger with a recording logger for the
+// duration of the test and returns it. Tests using this cannot run in
+// parallel with each other because backend.Logger is a global.
+func swapLogger(t *testing.T) *recordingLogger {
+	t.Helper()
+	rec := &recordingLogger{}
+	orig := backend.Logger
+	backend.Logger = rec
+	t.Cleanup(func() { backend.Logger = orig })
+	return rec
+}
+
+type logEntry struct {
+	level log.Level
+	msg   string
+	args  []interface{}
+}
+
+// kv returns args as a map[string]interface{}, treating consecutive
+// pairs as key/value. Odd-length args are ignored.
+func (e logEntry) kv() map[string]interface{} {
+	out := map[string]interface{}{}
+	for i := 0; i+1 < len(e.args); i += 2 {
+		k, ok := e.args[i].(string)
+		if !ok {
+			continue
+		}
+		out[k] = e.args[i+1]
+	}
+	return out
+}
+
+type recordingLogger struct {
+	mu      sync.Mutex
+	entries []logEntry
+}
+
+func (l *recordingLogger) record(level log.Level, msg string, args []interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, logEntry{level: level, msg: msg, args: args})
+}
+
+func (l *recordingLogger) Debug(msg string, args ...interface{}) { l.record(log.Debug, msg, args) }
+func (l *recordingLogger) Info(msg string, args ...interface{})  { l.record(log.Info, msg, args) }
+func (l *recordingLogger) Warn(msg string, args ...interface{})  { l.record(log.Warn, msg, args) }
+func (l *recordingLogger) Error(msg string, args ...interface{}) { l.record(log.Error, msg, args) }
+func (l *recordingLogger) With(_ ...interface{}) log.Logger      { return l }
+func (l *recordingLogger) Level() log.Level                      { return log.Debug }
+func (l *recordingLogger) FromContext(_ context.Context) log.Logger {
+	return l
+}

--- a/responseobs/responseobs_test.go
+++ b/responseobs/responseobs_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -144,6 +145,51 @@ func TestObserve_AppURLAbsent_EmptyField(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, rec.entries, 1)
 	assert.Equal(t, "", rec.entries[0].kv()["app_url"])
+}
+
+func TestObserve_Cross_IncrementsCounter(t *testing.T) {
+	swapLogger(t)
+
+	ds := backend.DataSourceInstanceSettings{Type: "counter-cross", UID: "ds-uid-1"}
+	appURL := "https://counter-cross.grafana.net/"
+	cfg := backend.NewGrafanaCfg(map[string]string{backend.AppURL: appURL})
+	ctx := backend.WithGrafanaConfig(context.Background(), cfg)
+
+	before := counterValue(t, ds.Type, appURL, ds.UID)
+	ok := Observe(ctx,
+		Observation{Datasource: ds, Rows: DefaultRowsThreshold},
+		Thresholds{Rows: DefaultRowsThreshold})
+
+	require.True(t, ok)
+	assert.Equal(t, before+1, counterValue(t, ds.Type, appURL, ds.UID))
+}
+
+func TestObserve_NoCross_DoesNotIncrementCounter(t *testing.T) {
+	swapLogger(t)
+
+	ds := backend.DataSourceInstanceSettings{Type: "counter-nocross", UID: "ds-uid-2"}
+
+	before := counterValue(t, ds.Type, "", ds.UID)
+	ok := Observe(context.Background(),
+		Observation{Datasource: ds, Rows: 10},
+		Thresholds{Rows: 1000})
+
+	require.False(t, ok)
+	assert.Equal(t, before, counterValue(t, ds.Type, "", ds.UID))
+}
+
+// counterValue reads the large-responses counter for a given label set.
+// Returns 0 if the series has not been created yet.
+func counterValue(t *testing.T, dsType, appURL, dsUID string) float64 {
+	t.Helper()
+	c, err := largeResponsesCounter.GetMetricWithLabelValues(dsType, appURL, dsUID)
+	require.NoError(t, err)
+	m := &dto.Metric{}
+	require.NoError(t, c.Write(m))
+	if m.Counter == nil {
+		return 0
+	}
+	return m.Counter.GetValue()
 }
 
 // swapLogger replaces backend.Logger with a recording logger for the


### PR DESCRIPTION
## Summary
- Introduces a narrow `responseobs` subpackage: `Thresholds`, `Observation`, `Observe(ctx, obs, t) bool`. Emits a single structured `warn` log when a response crosses either threshold; returns `bool` so a future counter can piggyback.
- Wires the helper through `DriverSettings.ResponseThresholds` → new `DBQuery.WithResponseThresholds(...)` setter (non-breaking; matches the `WithRowCapacityHint` convention). Defaults: 50 MiB bytes **or** 1M rows.
- Observation fires from the existing `observeResponseSize` hook in `convertRowsToFrames` — same call site as the histograms from #241, extended to also hand rows/cells/duration/refID to `responseobs.Observe`.

## Stacked on #241
This PR is based on `feat/response-size-histograms` (#241), not `main`. Merge #241 first, then this will rebase cleanly. Review this diff against that branch to see only PR 2's additions.

## Why
PR 2 of the measurement plan for grafana/data-sources#288 (PR 1 was sqlds#241). After maintainer guidance on SDK API stability and scope-beyond-datasources, the rich observation logic (threshold detection, structured log, and a counter in PR 3) lives in sqlds rather than the SDK. Only the transport-layer bytes observation in PR 4 stays SDK-side, because that's genuinely generic across plugin types.

## Design notes worth flagging in review
- **Bytes at sqlds layer are always 0.** Serialized wire size isn't cheaply measurable here — we'd need a hook inside `sqlutil.FrameFromRows` or an Arrow marshal. So only the rows threshold fires from sqlds. The bytes dimension remains in the API for layers that can measure it (and for operators who'd rather cap on bytes than rows once PR 4 lands).
- **`app_url` instead of `slug`.** The plan's log shape called for `slug`, but there's no dedicated slug accessor in `backend.GrafanaConfig` — only `AppURL()`. Logging the URL verbatim is honest; operators can parse in Loki/PromQL. Happy to revisit if reviewers prefer a derived `slug` field.
- **`QueryHash` deferred.** Field is on `Observation` but not populated here — the plan lists normalization cost as an open question; we can add it in a follow-up.
- **`DBQuery.Settings` was declared but never populated** (`NewQuery` didn't assign it). Fixed as a drive-by so the new log fields can pull Type/UID/Name without plumbing `PluginContext`. Happy to split that off if reviewers prefer.
- **Setter instead of new `NewQuery` arg.** Follows the `WithRowCapacityHint` pattern from a recent PR. External plugins calling `NewQuery` directly keep compiling; they opt in when they want thresholds.