### PR TITLE
feat(responseobs): add threshold-gated large-response counter

### DIFF
--- a/responseobs/counter.go
+++ b/responseobs/counter.go
@@ -1,0 +1,22 @@
+package responseobs
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// largeResponsesCounter increments once per Observation that crosses a
+// configured threshold. Cardinality is self-limiting because the counter
+// only increments on threshold crossings — the number of active series is
+// bounded by the number of datasource instances actually producing large
+// responses, not by total query volume.
+//
+// The app_url label carries the stack identifier. It replaces the earlier
+// "slug" label in the plan because backend.GrafanaConfig exposes no
+// dedicated slug accessor; downstream operators can derive a slug by
+// parsing the URL if needed.
+var largeResponsesCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "plugins",
+	Name:      "sql_large_responses_total",
+	Help:      "Number of SQL datasource responses that crossed a configured size threshold (rows or bytes).",
+}, []string{"datasource_type", "app_url", "datasource_uid"})

--- a/responseobs/responseobs.go
+++ b/responseobs/responseobs.go
@@ -56,15 +56,17 @@ type Observation struct {
 }
 
 // Observe compares obs against t. If a threshold is crossed, it emits a
-// single structured warn log via backend.Logger and returns true.
-// Otherwise it returns false and emits nothing. Intended to be called
-// at most once per response.
+// single structured warn log via backend.Logger, increments the
+// plugins_sql_large_responses_total counter, and returns true. Otherwise
+// it returns false and emits nothing. Intended to be called at most once
+// per response.
 func Observe(ctx context.Context, obs Observation, t Thresholds) bool {
 	if !crosses(obs, t) {
 		return false
 	}
+	appURL := appURLFromContext(ctx)
 	backend.Logger.Warn("large datasource response",
-		"app_url", appURLFromContext(ctx),
+		"app_url", appURL,
 		"datasource_type", obs.Datasource.Type,
 		"datasource_uid", obs.Datasource.UID,
 		"datasource_name", obs.Datasource.Name,
@@ -75,6 +77,7 @@ func Observe(ctx context.Context, obs Observation, t Thresholds) bool {
 		"ref_id", obs.RefID,
 		"query_hash", obs.QueryHash,
 	)
+	largeResponsesCounter.WithLabelValues(obs.Datasource.Type, appURL, obs.Datasource.UID).Inc()
 	return true
 }
 

--- a/responseobs/responseobs_test.go
+++ b/responseobs/responseobs_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -144,6 +145,51 @@ func TestObserve_AppURLAbsent_EmptyField(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, rec.entries, 1)
 	assert.Equal(t, "", rec.entries[0].kv()["app_url"])
+}
+
+func TestObserve_Cross_IncrementsCounter(t *testing.T) {
+	swapLogger(t)
+
+	ds := backend.DataSourceInstanceSettings{Type: "counter-cross", UID: "ds-uid-1"}
+	appURL := "https://counter-cross.grafana.net/"
+	cfg := backend.NewGrafanaCfg(map[string]string{backend.AppURL: appURL})
+	ctx := backend.WithGrafanaConfig(context.Background(), cfg)
+
+	before := counterValue(t, ds.Type, appURL, ds.UID)
+	ok := Observe(ctx,
+		Observation{Datasource: ds, Rows: DefaultRowsThreshold},
+		Thresholds{Rows: DefaultRowsThreshold})
+
+	require.True(t, ok)
+	assert.Equal(t, before+1, counterValue(t, ds.Type, appURL, ds.UID))
+}
+
+func TestObserve_NoCross_DoesNotIncrementCounter(t *testing.T) {
+	swapLogger(t)
+
+	ds := backend.DataSourceInstanceSettings{Type: "counter-nocross", UID: "ds-uid-2"}
+
+	before := counterValue(t, ds.Type, "", ds.UID)
+	ok := Observe(context.Background(),
+		Observation{Datasource: ds, Rows: 10},
+		Thresholds{Rows: 1000})
+
+	require.False(t, ok)
+	assert.Equal(t, before, counterValue(t, ds.Type, "", ds.UID))
+}
+
+// counterValue reads the large-responses counter for a given label set.
+// Returns 0 if the series has not been created yet.
+func counterValue(t *testing.T, dsType, appURL, dsUID string) float64 {
+	t.Helper()
+	c, err := largeResponsesCounter.GetMetricWithLabelValues(dsType, appURL, dsUID)
+	require.NoError(t, err)
+	m := &dto.Metric{}
+	require.NoError(t, c.Write(m))
+	if m.Counter == nil {
+		return 0
+	}
+	return m.Counter.GetValue()
 }
 
 // swapLogger replaces backend.Logger with a recording logger for the


### PR DESCRIPTION
## Summary

Adds a threshold-gated counter, `plugins_sql_large_responses_total`, inside the `responseobs` subpackage introduced by #242. The counter increments once per `Observation` that crosses a configured threshold — i.e. at the same decision point that fires the structured warn log in #242.

Stacked on #242 — base branch is `feat/responseobs`, not `main`. Review #242 first; the diff here shows only the counter additions.

## Shape

```
plugins_sql_large_responses_total counter{datasource_type, app_url, datasource_uid}
```

## Cardinality note for reviewers

This is the part most likely to draw a reflexive reject, so calling it out:

- Increments happen **only when a threshold is crossed** (default 50 MiB OR 1M rows, per #242). Normal-sized responses produce no new series.
- Steady-state series count ≈ (stacks with abusive queries) × (avg large-datasource-instances per stack). Order of magnitude: tens to hundreds, not tens of thousands.
- Contrast with the histograms in #241, which are `{datasource_type}` only. Putting `app_url`/`uid` on the histogram would have blown Mimir limits; putting them on this threshold-gated counter is the intended trade — per-stack identification for alerting, but the gate prevents unbounded growth.

If cardinality does prove higher than estimated in production, a Prometheus relabel drop on `app_url` is the immediate mitigation — documented here so oncall doesn't have to rediscover it.

## Label choices

- **`app_url` replaces `slug`.** `backend.GrafanaConfig` exposes `AppURL()` but no dedicated slug accessor. The #242 log field uses `app_url` for the same reason — keeping labels consistent between log and counter. If anyone knows a reliable slug source I missed, happy to switch.
- **`datasource_uid` included** (not on histograms) — the counter is where operators drill into a specific abusive datasource instance, so the UID is load-bearing. The threshold gate makes the cardinality cost acceptable.
- **No `datasource_name`** — would require label sanitization (names can have spaces/special chars). UID is sufficient for identification.

## Integration point

One line in `Observe`:

```go
largeResponsesCounter.WithLabelValues(obs.Datasource.Type, appURL, obs.Datasource.UID).Inc()
```

Placed right after the `backend.Logger.Warn` call. No caller-side changes needed — every consumer of `responseobs.Observe` picks up the counter automatically.

## Suggested alert (for downstream consumers)

Not shipping alert rules — the consuming team owns that. Suggested shape:

```promql
sum by (datasource_type, app_url, datasource_uid) (
  rate(plugins_sql_large_responses_total[15m])
) > 0
```

i.e. "any SQL datasource producing large responses in the last 15m". Tune as needed.