### PR TITLE
fix: classify closed connection pool errors as downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.2]
+
+### Fixed
+
+- Classify a closed connection pool (`sql: database is closed` / `sql.ErrConnDone`) as a downstream error instead of a plugin error. This error is collateral from sqlds tearing down or reconnecting the shared `*sql.DB` while a concurrent query is in flight, not a plugin fault.
+
 ## [5.1.1]
 
 ### Fixed

--- a/connector.go
+++ b/connector.go
@@ -170,7 +170,16 @@ func (c *Connector) storeDBConnection(key string, dbConn CachedConnection) {
 
 // Dispose is called when an existing SQLDatasource needs to be replaced
 func (c *Connector) Dispose() {
-	c.connCache().Dispose()
+	cache := c.connCache()
+	// Log each pool being torn down before delegating the actual close to the
+	// cache. Disposal is otherwise silent, so an over-aggressive disposal
+	// (e.g. settings churn) can't be correlated with the closed-pool downstream
+	// errors it produces (see isConnectionClosedError / DBQuery.Run).
+	cache.Range(func(key string, _ CachedConnection) bool {
+		backend.Logger.Debug("disposing db connection pool", "key", key)
+		return true
+	})
+	cache.Dispose()
 }
 
 func (c *Connector) GetConnectionFromQuery(ctx context.Context, q *Query) (string, CachedConnection, error) {

--- a/errors.go
+++ b/errors.go
@@ -1,7 +1,9 @@
 package sqlds
 
 import (
+	"database/sql"
 	"errors"
+	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
@@ -28,4 +30,24 @@ func ErrorSource(err error) backend.ErrorSource {
 		return backend.ErrorSourceDownstream
 	}
 	return backend.ErrorSourcePlugin
+}
+
+// isConnectionClosedError reports whether err indicates the underlying
+// *sql.DB connection pool has been closed. This happens as a side effect of
+// sqlds tearing down or reconnecting the shared connection (see
+// Connector.Dispose / Connector.Reconnect), typically while a concurrent
+// query is still in flight, so it should be treated as a downstream error
+// rather than counted against the plugin.
+//
+// database/sql returns an unexported sentinel ("sql: database is closed")
+// when the pool is closed, so we match its message in addition to the
+// exported sql.ErrConnDone ("sql: connection is already closed").
+func isConnectionClosedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, sql.ErrConnDone) {
+		return true
+	}
+	return strings.Contains(err.Error(), "sql: database is closed")
 }

--- a/query.go
+++ b/query.go
@@ -89,6 +89,16 @@ func (q *DBQuery) Run(ctx context.Context, query *Query, queryErrorMutator Query
 			return sqlutil.ErrorFrameFromQuery(query), errWithSource
 		}
 
+		// A closed connection pool is collateral from sqlds tearing down or
+		// reconnecting the shared *sql.DB (see Connector.Dispose / Reconnect),
+		// not a plugin fault. Classify it as downstream so it does not count
+		// against the plugin's error budget.
+		if isConnectionClosedError(err) {
+			queryErr := fmt.Errorf("%w: %w", ErrorQuery, err)
+			errWithSource = backend.NewErrorWithSource(queryErr, backend.ErrorSourceDownstream)
+			return sqlutil.ErrorFrameFromQuery(query), errWithSource
+		}
+
 		// Wrap with ErrorQuery to enable retry logic in datasource
 		queryErr := fmt.Errorf("%w: %w", ErrorQuery, err)
 
@@ -109,6 +119,10 @@ func (q *DBQuery) Run(ctx context.Context, query *Query, queryErrorMutator Query
 	if err := rows.Err(); err != nil {
 		queryErr := fmt.Errorf("%w: %w", ErrorQuery, err)
 		errWithSource := backend.NewErrorWithSource(queryErr, backend.DefaultErrorSource)
+		if isConnectionClosedError(err) {
+			q.metrics.CollectDuration(SourceDownstream, StatusError, time.Since(start).Seconds())
+			return sqlutil.ErrorFrameFromQuery(query), backend.DownstreamErrorf("%w: %w", ErrorQuery, err)
+		}
 		if errors.Is(err, sql.ErrNoRows) {
 			// Should we even response with an error here?
 			// The panel will simply show "no data"

--- a/query.go
+++ b/query.go
@@ -119,10 +119,6 @@ func (q *DBQuery) Run(ctx context.Context, query *Query, queryErrorMutator Query
 	if err := rows.Err(); err != nil {
 		queryErr := fmt.Errorf("%w: %w", ErrorQuery, err)
 		errWithSource := backend.NewErrorWithSource(queryErr, backend.DefaultErrorSource)
-		if isConnectionClosedError(err) {
-			q.metrics.CollectDuration(SourceDownstream, StatusError, time.Since(start).Seconds())
-			return sqlutil.ErrorFrameFromQuery(query), backend.DownstreamErrorf("%w: %w", ErrorQuery, err)
-		}
 		if errors.Is(err, sql.ErrNoRows) {
 			// Should we even response with an error here?
 			// The panel will simply show "no data"

--- a/query.go
+++ b/query.go
@@ -94,6 +94,8 @@ func (q *DBQuery) Run(ctx context.Context, query *Query, queryErrorMutator Query
 		// not a plugin fault. Classify it as downstream so it does not count
 		// against the plugin's error budget.
 		if isConnectionClosedError(err) {
+			backend.Logger.Debug("query hit a closed connection pool; classifying as downstream",
+				"refID", query.RefID, "error", err.Error())
 			queryErr := fmt.Errorf("%w: %w", ErrorQuery, err)
 			errWithSource = backend.NewErrorWithSource(queryErr, backend.ErrorSourceDownstream)
 			return sqlutil.ErrorFrameFromQuery(query), errWithSource

--- a/query_streaming_test.go
+++ b/query_streaming_test.go
@@ -1,0 +1,94 @@
+package sqlds
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+	"github.com/stretchr/testify/require"
+)
+
+// The fake driver below yields a *sql.Rows whose Next fails, simulating the
+// connection pool being torn down (see Connector.Dispose / Reconnect) while a
+// query is being streamed. Unlike a failure from QueryContext, this error
+// surfaces during row iteration in convertRowsToFrames / getFrames.
+//
+// DBQuery.Run does not special-case the closed pool on this path: it relies on
+// sqlutil.FrameFromRows wrapping rows.Err() in backend.DownstreamError, which
+// convertRowsToFrames then honours via backend.IsDownstreamHTTPError. This test
+// pins that behaviour so a future change to either layer can't silently start
+// counting a torn-down pool against the plugin's error budget.
+
+type streamErrConnector struct{ rowErr error }
+
+func (c streamErrConnector) Connect(context.Context) (driver.Conn, error) {
+	return &streamErrConn{c.rowErr}, nil
+}
+func (c streamErrConnector) Driver() driver.Driver { return streamErrDriver{c.rowErr} }
+
+type streamErrDriver struct{ rowErr error }
+
+func (d streamErrDriver) Open(string) (driver.Conn, error) { return &streamErrConn{d.rowErr}, nil }
+
+type streamErrConn struct{ rowErr error }
+
+func (c *streamErrConn) Prepare(string) (driver.Stmt, error) { return &streamErrStmt{c.rowErr}, nil }
+func (c *streamErrConn) Close() error                        { return nil }
+func (c *streamErrConn) Begin() (driver.Tx, error)           { return nil, errors.New("not supported") }
+func (c *streamErrConn) QueryContext(_ context.Context, _ string, _ []driver.NamedValue) (driver.Rows, error) {
+	return &streamErrRows{rowErr: c.rowErr}, nil
+}
+
+type streamErrStmt struct{ rowErr error }
+
+func (s *streamErrStmt) Close() error  { return nil }
+func (s *streamErrStmt) NumInput() int { return -1 }
+func (s *streamErrStmt) Exec([]driver.Value) (driver.Result, error) {
+	return nil, errors.New("not supported")
+}
+func (s *streamErrStmt) Query([]driver.Value) (driver.Rows, error) {
+	return &streamErrRows{rowErr: s.rowErr}, nil
+}
+
+type streamErrRows struct{ rowErr error }
+
+func (r *streamErrRows) Columns() []string           { return []string{"col"} }
+func (r *streamErrRows) Close() error                { return nil }
+func (r *streamErrRows) Next(_ []driver.Value) error { return r.rowErr } // pool closed mid-stream
+
+func TestRun_ConnectionClosedDuringStreamingIsDownstream(t *testing.T) {
+	settings := backend.DataSourceInstanceSettings{Name: "test"}
+	query := &Query{RawSQL: "SELECT * FROM test", RefID: "A"}
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"sql: database is closed", errors.New("sql: database is closed")},
+		{"sql.ErrConnDone", sql.ErrConnDone},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := sql.OpenDB(streamErrConnector{rowErr: tc.err})
+			defer db.Close()
+
+			dbQuery := NewQuery(db, settings, []sqlutil.Converter{}, nil, defaultRowLimit)
+
+			// A driver mutator that would otherwise misclassify as plugin must
+			// not flip the classification: the streaming path is already
+			// downstream before the mutator is consulted.
+			_, err := dbQuery.Run(context.Background(), query, &mockErrorMutator{shouldMutate: false})
+
+			require.Error(t, err)
+			var errWithSource backend.ErrorWithSource
+			require.True(t, errors.As(err, &errWithSource), "should implement ErrorWithSource")
+			require.Equal(t, backend.ErrorSourceDownstream, errWithSource.ErrorSource(),
+				"pool closed during streaming must be classified as downstream")
+		})
+	}
+}

--- a/query_test.go
+++ b/query_test.go
@@ -27,6 +27,9 @@ type testConnection struct {
 
 	QueryWait     time.Duration
 	QueryRunCount int
+	// QueryErr, when set, is returned immediately by QueryContext instead of
+	// the default errorQueryCompleted.
+	QueryErr error
 }
 
 func (t *testConnection) Close() error {
@@ -55,6 +58,10 @@ func (t *testConnection) PingContext(ctx context.Context) error {
 
 func (t *testConnection) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
 	t.QueryRunCount++
+
+	if t.QueryErr != nil {
+		return nil, t.QueryErr
+	}
 
 	done := make(chan bool)
 	go func() {
@@ -351,6 +358,38 @@ func TestRun_ErrorQueryWrapping(t *testing.T) {
 		require.True(t, errors.Is(receivedErr, ErrorQuery), "Mutator should receive ErrorQuery-wrapped error")
 		require.True(t, errors.Is(receivedErr, errorQueryCompleted), "Original error should be in chain")
 	})
+}
+
+func TestRun_ConnectionClosedIsDownstream(t *testing.T) {
+	settings := backend.DataSourceInstanceSettings{Name: "test"}
+	query := &Query{RawSQL: "SELECT * FROM test", RefID: "A"}
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"sql: database is closed", errors.New("sql: database is closed")},
+		{"wrapped database is closed", fmt.Errorf("driver failure: %w", errors.New("sql: database is closed"))},
+		{"sql.ErrConnDone", sql.ErrConnDone},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &testConnection{QueryErr: tc.err}
+			dbQuery := NewQuery(conn, settings, []sqlutil.Converter{}, nil, defaultRowLimit)
+
+			// A driver mutator that would otherwise misclassify as plugin must
+			// not override the connection-closed downstream classification.
+			_, err := dbQuery.Run(context.Background(), query, &mockErrorMutator{shouldMutate: false})
+
+			require.Error(t, err)
+			require.True(t, errors.Is(err, ErrorQuery), "should be wrapped with ErrorQuery")
+			var errWithSource backend.ErrorWithSource
+			require.True(t, errors.As(err, &errWithSource), "should implement ErrorWithSource")
+			require.Equal(t, backend.ErrorSourceDownstream, errWithSource.ErrorSource(),
+				"closed connection pool must be classified as downstream")
+		})
+	}
 }
 
 func TestCollectResponseSize(t *testing.T) {


### PR DESCRIPTION
## Problem

Queries failing with `error querying the database: sql: database is closed` were reported with `statusSource=plugin`, counting against the plugin's error budget. Example (CockroachDB):

```
msg="Partial data response error" refID=A status=500 error="error querying the database: sql: database is closed" statusSource=plugin target=remote
```

`sql: database is closed` (and `sql.ErrConnDone`) is returned by `database/sql` when `QueryContext` runs against a `*sql.DB` whose pool has already been closed. In sqlds this is collateral from `Connector.Dispose` / `Connector.Reconnect` closing the shared connection while a concurrent query is in flight — not a plugin fault.

## Why this belongs in sqlds (and before the driver mutator)

- The closed pool is created by sqlds's own lifecycle code (`Dispose`/`Reconnect`); the plugin has no control over it.
- The error is generic to `database/sql`, not driver-specific, so it affects every sqlds consumer (postgres, mysql, snowflake, bigquery, …).
- It must run **before** the `QueryErrorMutator`: CockroachDB's mutator defaults unknown errors to `plugin` (`sql: database is closed` is not a `pgconn.PgError`), so it would otherwise re-label the lifecycle error. Flipping `DefaultErrorSource` can't fix this either, since the mutator short-circuits that path.

## Changes

- `errors.go`: add `isConnectionClosedError` (`sql.ErrConnDone` + `"sql: database is closed"` message match — the pool-closed sentinel is unexported in `database/sql`).
- `query.go`: classify closed-pool errors as downstream in both the `QueryContext` and `rows.Err()` paths in `DBQuery.Run`, before the driver mutator. The `ErrorQuery` wrap is preserved.
- `query_test.go`: `TestRun_ConnectionClosedIsDownstream` covering the bare message, a wrapped message, and `sql.ErrConnDone`, and asserting a plugin-defaulting mutator cannot override the classification.
- `CHANGELOG.md`: `[5.1.2]` Fixed entry.