### PR TITLE
fix: defer bootstrap Connect so CallResource works without a live DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.1]
+
+### Fixed
+
+- Soft-fail bootstrap `Connect` in `NewConnector` so CallResource routes can register when the DB is not ready yet; connect on demand from query and health paths by @iwysiu in #305
+
 ## [5.3.0]
 
 ### Added

--- a/connector.go
+++ b/connector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -20,6 +21,8 @@ type Connector struct {
 	// fmt.Sprintf("%s-default", UID) and never changes for the life of the
 	// connector, so we compute it once in NewConnector.
 	defaultKey string
+	// defaultDBMu serializes opening a deferred default connection.
+	defaultDBMu sync.Mutex
 	// Enabling multiple connections may cause that concurrent connection limits
 	// are hit. The datasource enabling this should make sure connections are cached
 	// if necessary.
@@ -67,17 +70,9 @@ func NewConnector(ctx context.Context, driver Driver, settings backend.DataSourc
 
 func (c *Connector) Connect(ctx context.Context, headers http.Header) (*CachedConnection, error) {
 	key := c.defaultKey
-	dbConn, ok := c.getDBConnection(key)
-	if !ok {
-		return nil, ErrorMissingDBConnection
-	}
-	if dbConn.db == nil {
-		db, err := c.driver.Connect(ctx, dbConn.settings, nil)
-		if err != nil {
-			return nil, backend.DownstreamError(err)
-		}
-		dbConn = CachedConnection{db: db, settings: dbConn.settings}
-		c.storeDBConnection(key, dbConn)
+	dbConn, err := c.ensureDefaultDB(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if c.driverSettings.Retries == 0 {
@@ -85,8 +80,37 @@ func (c *Connector) Connect(ctx context.Context, headers http.Header) (*CachedCo
 		return nil, err
 	}
 
-	err := c.connectWithRetries(ctx, dbConn, key, headers)
+	err = c.connectWithRetries(ctx, dbConn, key, headers)
 	return &dbConn, err
+}
+
+func (c *Connector) ensureDefaultDB(ctx context.Context) (CachedConnection, error) {
+	dbConn, ok := c.getDBConnection(c.defaultKey)
+	if !ok {
+		return CachedConnection{}, ErrorMissingDBConnection
+	}
+	if dbConn.db != nil {
+		return dbConn, nil
+	}
+
+	c.defaultDBMu.Lock()
+	defer c.defaultDBMu.Unlock()
+
+	dbConn, ok = c.getDBConnection(c.defaultKey)
+	if !ok {
+		return CachedConnection{}, ErrorMissingDBConnection
+	}
+	if dbConn.db != nil {
+		return dbConn, nil
+	}
+
+	db, err := c.driver.Connect(ctx, dbConn.settings, nil)
+	if err != nil {
+		return CachedConnection{}, backend.DownstreamError(err)
+	}
+	dbConn = CachedConnection{db: db, settings: dbConn.settings}
+	c.storeDBConnection(c.defaultKey, dbConn)
+	return dbConn, nil
 }
 
 func (c *Connector) connectWithRetries(ctx context.Context, conn CachedConnection, key string, headers http.Header) error {
@@ -153,8 +177,10 @@ func (c *Connector) Reconnect(ctx context.Context, dbConn CachedConnection, q *Q
 		return nil, backend.DownstreamError(err)
 	}
 
-	if err = dbConn.db.Close(); err != nil {
-		backend.Logger.Warn(fmt.Sprintf("closing existing connection failed: %s", err.Error()))
+	if dbConn.db != nil {
+		if err = dbConn.db.Close(); err != nil {
+			backend.Logger.Warn(fmt.Sprintf("closing existing connection failed: %s", err.Error()))
+		}
 	}
 
 	c.storeDBConnection(cacheKey, CachedConnection{db, dbConn.settings})
@@ -193,17 +219,9 @@ func (c *Connector) GetConnectionFromQuery(ctx context.Context, q *Query) (strin
 	// The database connection may vary depending on query arguments
 	// The raw arguments are used as key to store the db connection in memory so they can be reused
 	key := c.defaultKey
-	dbConn, ok := c.getDBConnection(key)
-	if !ok {
-		return "", CachedConnection{}, MissingDBConnection
-	}
-	if dbConn.db == nil {
-		db, err := c.driver.Connect(ctx, dbConn.settings, nil)
-		if err != nil {
-			return "", CachedConnection{}, backend.DownstreamError(err)
-		}
-		dbConn = CachedConnection{db: db, settings: dbConn.settings}
-		c.storeDBConnection(key, dbConn)
+	dbConn, err := c.ensureDefaultDB(ctx)
+	if err != nil {
+		return "", CachedConnection{}, err
 	}
 	if !c.enableMultipleConnections || len(q.ConnectionArgs) == 0 {
 		backend.Logger.Debug("using single user connection")

--- a/connector.go
+++ b/connector.go
@@ -40,6 +40,10 @@ func WithCache(cache ConnectionCache) ConnectorOption {
 	return func(c *Connector) { c.cache = cache }
 }
 
+// NewConnector creates a Connector. A failed initial driver.Connect is not
+// returned as an error: the Connector is still created so CallResource routes
+// can register, and connecting is retried on demand by the first query or
+// health check — which is where a persistent failure surfaces.
 func NewConnector(ctx context.Context, driver Driver, settings backend.DataSourceInstanceSettings, enableMultipleConnections bool, opts ...ConnectorOption) (*Connector, error) {
 	ds := driver.Settings(ctx, settings)
 

--- a/connector.go
+++ b/connector.go
@@ -39,10 +39,6 @@ func WithCache(cache ConnectionCache) ConnectorOption {
 
 func NewConnector(ctx context.Context, driver Driver, settings backend.DataSourceInstanceSettings, enableMultipleConnections bool, opts ...ConnectorOption) (*Connector, error) {
 	ds := driver.Settings(ctx, settings)
-	db, err := driver.Connect(ctx, settings, nil)
-	if err != nil {
-		return nil, backend.DownstreamError(err)
-	}
 
 	conn := &Connector{
 		UID:                       settings.UID,
@@ -57,6 +53,14 @@ func NewConnector(ctx context.Context, driver Driver, settings backend.DataSourc
 	if conn.cache == nil {
 		conn.cache = NewSyncMapCache()
 	}
+
+	db, err := driver.Connect(ctx, settings, nil)
+	if err != nil {
+		backend.Logger.Warn("bootstrap connect deferred; CallResource routes will still register", "error", err)
+		conn.storeDBConnection(conn.defaultKey, CachedConnection{db: nil, settings: settings})
+		return conn, nil
+	}
+
 	conn.storeDBConnection(conn.defaultKey, CachedConnection{db, settings})
 	return conn, nil
 }
@@ -66,6 +70,14 @@ func (c *Connector) Connect(ctx context.Context, headers http.Header) (*CachedCo
 	dbConn, ok := c.getDBConnection(key)
 	if !ok {
 		return nil, ErrorMissingDBConnection
+	}
+	if dbConn.db == nil {
+		db, err := c.driver.Connect(ctx, dbConn.settings, nil)
+		if err != nil {
+			return nil, backend.DownstreamError(err)
+		}
+		dbConn = CachedConnection{db: db, settings: dbConn.settings}
+		c.storeDBConnection(key, dbConn)
 	}
 
 	if c.driverSettings.Retries == 0 {
@@ -184,6 +196,14 @@ func (c *Connector) GetConnectionFromQuery(ctx context.Context, q *Query) (strin
 	dbConn, ok := c.getDBConnection(key)
 	if !ok {
 		return "", CachedConnection{}, MissingDBConnection
+	}
+	if dbConn.db == nil {
+		db, err := c.driver.Connect(ctx, dbConn.settings, nil)
+		if err != nil {
+			return "", CachedConnection{}, backend.DownstreamError(err)
+		}
+		dbConn = CachedConnection{db: db, settings: dbConn.settings}
+		c.storeDBConnection(key, dbConn)
 	}
 	if !c.enableMultipleConnections || len(q.ConnectionArgs) == 0 {
 		backend.Logger.Debug("using single user connection")

--- a/connector_deferred_test.go
+++ b/connector_deferred_test.go
@@ -1,0 +1,72 @@
+package sqlds
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
+)
+
+type deferDriver struct {
+	connectErr error
+	db         *sql.DB
+	calls      int
+}
+
+func (d *deferDriver) Connect(_ context.Context, _ backend.DataSourceInstanceSettings, _ json.RawMessage) (*sql.DB, error) {
+	d.calls++
+	if d.connectErr != nil {
+		return nil, d.connectErr
+	}
+	return d.db, nil
+}
+func (d *deferDriver) Settings(context.Context, backend.DataSourceInstanceSettings) DriverSettings {
+	return DriverSettings{}
+}
+func (d *deferDriver) Macros() Macros                  { return Macros{} }
+func (d *deferDriver) Converters() []sqlutil.Converter { return nil }
+
+func TestNewConnector_SoftFailsBootstrapConnect(t *testing.T) {
+	d := &deferDriver{connectErr: errors.New("trying to use non-allowed auth method default")}
+	conn, err := NewConnector(context.Background(), d, backend.DataSourceInstanceSettings{UID: "uid"}, false)
+	if err != nil {
+		t.Fatalf("expected NewConnector to succeed with deferred connect, got %v", err)
+	}
+	cached, ok := conn.getDBConnection(defaultKey("uid"))
+	if !ok {
+		t.Fatal("expected settings stub under default key")
+	}
+	if cached.db != nil {
+		t.Fatal("expected nil db when bootstrap Connect failed")
+	}
+	if cached.settings.UID != "uid" {
+		t.Fatalf("expected settings preserved, got %+v", cached.settings)
+	}
+}
+
+func TestGetConnectionFromQuery_ConnectsWhenBootstrapDeferred(t *testing.T) {
+	live := &sql.DB{}
+	d := &deferDriver{connectErr: errors.New("not ready yet")}
+	conn, err := NewConnector(context.Background(), d, backend.DataSourceInstanceSettings{UID: "uid"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// First Connect failed; clear error so on-demand succeeds
+	d.connectErr = nil
+	d.db = live
+
+	_, cached, err := conn.GetConnectionFromQuery(context.Background(), &Query{})
+	if err != nil {
+		t.Fatalf("expected on-demand connect, got %v", err)
+	}
+	if cached.db != live {
+		t.Fatalf("expected live db, got %v", cached.db)
+	}
+	if d.calls < 2 {
+		t.Fatalf("expected bootstrap + on-demand Connect calls, got %d", d.calls)
+	}
+}

--- a/connector_deferred_test.go
+++ b/connector_deferred_test.go
@@ -5,7 +5,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
@@ -68,5 +71,70 @@ func TestGetConnectionFromQuery_ConnectsWhenBootstrapDeferred(t *testing.T) {
 	}
 	if d.calls < 2 {
 		t.Fatalf("expected bootstrap + on-demand Connect calls, got %d", d.calls)
+	}
+}
+
+type concurrentDeferDriver struct {
+	live  *sql.DB
+	calls atomic.Int32
+	gate  chan struct{}
+}
+
+func (d *concurrentDeferDriver) Connect(_ context.Context, _ backend.DataSourceInstanceSettings, _ json.RawMessage) (*sql.DB, error) {
+	if d.calls.Add(1) == 1 {
+		return nil, errors.New("not ready yet")
+	}
+	<-d.gate
+	return d.live, nil
+}
+
+func (d *concurrentDeferDriver) Settings(context.Context, backend.DataSourceInstanceSettings) DriverSettings {
+	return DriverSettings{}
+}
+func (d *concurrentDeferDriver) Macros() Macros                  { return Macros{} }
+func (d *concurrentDeferDriver) Converters() []sqlutil.Converter { return nil }
+
+func TestGetConnectionFromQuery_ConcurrentDeferredConnectOpensOnce(t *testing.T) {
+	const workers = 16
+
+	d := &concurrentDeferDriver{live: &sql.DB{}, gate: make(chan struct{})}
+	conn, err := NewConnector(context.Background(), d, backend.DataSourceInstanceSettings{UID: "uid"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			<-start
+			_, cached, err := conn.GetConnectionFromQuery(context.Background(), &Query{})
+			if err == nil && cached.db != d.live {
+				err = errors.New("expected cached live db")
+			}
+			errs <- err
+		}()
+	}
+
+	close(start)
+	deadline := time.Now().Add(time.Second)
+	for d.calls.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(25 * time.Millisecond)
+	close(d.gate)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := d.calls.Load(); got != 2 {
+		t.Fatalf("expected bootstrap plus one on-demand Connect call, got %d", got)
 	}
 }

--- a/datasource_middleware_test.go
+++ b/datasource_middleware_test.go
@@ -2,9 +2,14 @@ package sqlds_test
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 	"github.com/grafana/sqlds/v5"
 	"github.com/grafana/sqlds/v5/test"
 	"github.com/stretchr/testify/assert"
@@ -42,6 +47,37 @@ func Test_resource_middleware_nil_is_skipped(t *testing.T) {
 	_, err := ds.NewDatasource(context.Background(), settings)
 	assert.Nil(t, err)
 	assert.NotNil(t, ds.CallResourceHandler, "expected CallResourceHandler to be set even without middleware")
+}
+
+type failingResourceDriver struct{}
+
+func (failingResourceDriver) Connect(context.Context, backend.DataSourceInstanceSettings, json.RawMessage) (*sql.DB, error) {
+	return nil, errors.New("connect failed")
+}
+func (failingResourceDriver) Settings(context.Context, backend.DataSourceInstanceSettings) sqlds.DriverSettings {
+	return sqlds.DriverSettings{}
+}
+func (failingResourceDriver) Macros() sqlds.Macros            { return nil }
+func (failingResourceDriver) Converters() []sqlutil.Converter { return nil }
+
+func Test_custom_route_works_when_bootstrap_connect_is_deferred(t *testing.T) {
+	ds := sqlds.NewDatasource(failingResourceDriver{})
+	ds.CustomRoutes = map[string]func(http.ResponseWriter, *http.Request){
+		"/custom": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		},
+	}
+
+	settings := backend.DataSourceInstanceSettings{UID: "deferred-custom-route"}
+	_, err := ds.NewDatasource(context.Background(), settings)
+	assert.NoError(t, err)
+
+	sender := &fakeResourceSender{}
+	err = ds.CallResource(context.Background(), &backend.CallResourceRequest{Path: "custom", Method: http.MethodGet}, sender)
+	assert.NoError(t, err)
+	if assert.NotNil(t, sender.response) {
+		assert.Equal(t, http.StatusOK, sender.response.Status)
+	}
 }
 
 // fakeResourceSender captures the last sent response.

--- a/health_test.go
+++ b/health_test.go
@@ -56,7 +56,7 @@ func TestHealthChecker_Check(t *testing.T) {
 			PostCheckHealth: func(ctx context.Context, req *backend.CheckHealthRequest) *backend.CheckHealthResult {
 				return &backend.CheckHealthResult{Status: backend.HealthStatusOk}
 			},
-			want: &backend.CheckHealthResult{Status: backend.HealthStatusError, Message: "unable to get default db connection"},
+			want: &backend.CheckHealthResult{Status: backend.HealthStatusError, Message: "failed to create mock"},
 		},
 		{
 			name:      "should not error when post check succeed",


### PR DESCRIPTION
## Summary
- Soft-fail bootstrap `Connect` in `NewConnector` so datasource instance init still succeeds when the DB/AWS client is not ready (e.g. incomplete config falling back to a non-allowed auth method). Settings are stored with a nil DB stub so `CustomRoutes` / CallResource can register.
- Open the default connection on demand from query and health paths via `ensureDefaultDB`, with a mutex so concurrent first queries do not leak duplicate connections.
- Add regression coverage for deferred bootstrap, concurrent on-demand open, and a custom CallResource route succeeding after Connect fails.

This unblocks Athena/Redshift Grafana Assume Role `/externalId` on Cloud, where eager connect previously failed instance init before the route ran. The failed init meant that the resources wouldn't be registered and we couldn't get the external id for the user. The thing is that the externalid does not require the ds to actually connect before we get it (and we don't have the connection info at that point to do it) so this changes it to return an incomplete connection so that we can get the externalid

**Downstream drafts (merge after this):**
1. [grafana/grafana-aws-sdk#482](https://github.com/grafana/grafana-aws-sdk/pull/482) — defer async DB connect
2. [grafana/athena-datasource#885](https://github.com/grafana/athena-datasource/pull/885) — wire Athena to those tips

## Test plan
- [x] `go test ./... -count=1` in this branch
- [x] Local Athena verify: Cloud-like `allowed_auth_providers` without `default`; incomplete Athena DS; `POST .../resources/externalId` → 200 (with local grafana-aws-sdk consumer of this change)
- [ ] CI green on this PR
- [ ] Review call sites that assumed `NewConnector` hard-fails on Connect error