### PR TITLE
fix: guard the long-to-wide pivot with a projected-cell budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.4.0]
+
+### Changed
+
+- The long-to-wide pivot in the time-series format is now guarded by a projected-cell budget, on by default: a long result whose wide projection exceeds `DriverSettings.LongToWideCellLimit` (default 10,000,000 cells) fails with a downstream error before any wide-frame memory is allocated, instead of expanding to rows x series cells and exhausting the plugin process's memory. Queries that previously returned very large wide frames now return an error. Set `LongToWideCellLimit: -1` to restore the old behaviour by @adamyeats in #307
+
 ## [5.3.1]
 
 ### Fixed

--- a/datasource.go
+++ b/datasource.go
@@ -102,6 +102,9 @@ type SQLDatasource struct {
 	// at init and passed into every DBQuery so FrameFromRows can presize
 	// its Fields. Zero disables presizing.
 	rowCapacityHint int64
+	// longToWideCellLimit mirrors DriverSettings.LongToWideCellLimit, resolved
+	// per query inside getFrames (0 = default, negative = disabled).
+	longToWideCellLimit int64
 	// PreCheckHealth (optional). Performs custom health check before the Connect method
 	PreCheckHealth func(ctx context.Context, req *backend.CheckHealthRequest) *backend.CheckHealthResult
 	// PostCheckHealth (optional).Performs custom health check after the Connect method
@@ -153,6 +156,7 @@ func (ds *SQLDatasource) NewDatasource(ctx context.Context, settings backend.Dat
 
 	ds.rowLimit = ds.newRowLimit(ctx, conn)
 	ds.rowCapacityHint = conn.driverSettings.RowCapacityHint
+	ds.longToWideCellLimit = conn.driverSettings.LongToWideCellLimit
 
 	return ds, nil
 }
@@ -312,6 +316,7 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 	//    if the query fails. NOTE: this does not include some errors like "ErrNoRows"
 	dbQuery := NewQuery(dbConn.db, dbConn.settings, ds.cachedConverters, fillMode, ds.rowLimit).
 		WithRowCapacityHint(ds.rowCapacityHint).
+		WithLongToWideCellLimit(ds.longToWideCellLimit).
 		WithResponseThresholds(ds.DriverSettings().ResponseThresholds)
 	res, err := dbQuery.Run(ctx, q, queryErrorMutator, args...)
 	if err == nil {
@@ -340,6 +345,7 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 
 				dbQuery := NewQuery(db, dbConn.settings, ds.cachedConverters, fillMode, ds.rowLimit).
 					WithRowCapacityHint(ds.rowCapacityHint).
+					WithLongToWideCellLimit(ds.longToWideCellLimit).
 					WithResponseThresholds(ds.DriverSettings().ResponseThresholds)
 				res, err = dbQuery.Run(ctx, q, queryErrorMutator, args...)
 				if err == nil {
@@ -371,7 +377,8 @@ func (ds *SQLDatasource) handleQuery(ctx context.Context, req backend.DataQuery,
 			}
 
 			dbQuery := NewQuery(db, dbConn.settings, ds.cachedConverters, fillMode, ds.rowLimit).
-				WithRowCapacityHint(ds.rowCapacityHint)
+				WithRowCapacityHint(ds.rowCapacityHint).
+				WithLongToWideCellLimit(ds.longToWideCellLimit)
 			res, err = dbQuery.Run(ctx, q, queryErrorMutator, args...)
 			if err == nil {
 				return res, err

--- a/driver.go
+++ b/driver.go
@@ -30,6 +30,15 @@ type DriverSettings struct {
 	// patterns, statements with a hard LIMIT) should set this to avoid
 	// per-column slice growth during FrameFromRows.
 	RowCapacityHint int64
+	// LongToWideCellLimit bounds the wide frame the time-series format builds
+	// from a long result. The projected size is distinct timestamps x
+	// (1 + distinct label combinations x value fields), in cells. When the
+	// projection exceeds the limit, the query fails with a downstream error
+	// before any wide-frame memory is allocated: high-cardinality results
+	// otherwise expand to rows x series cells, mostly null, and can exhaust
+	// the plugin process's memory. 0 (the default) applies a limit of
+	// 10,000,000 cells. A negative value disables the guard.
+	LongToWideCellLimit int64
 	// ResponseThresholds configures when a query response is considered
 	// "large" enough to emit a structured warn log. A zero value on
 	// either field disables that dimension. At the sqlds layer bytes

--- a/errors.go
+++ b/errors.go
@@ -21,6 +21,10 @@ var (
 	ErrorRowValidation = errors.New("SQL rows validation failed")
 	// ErrorConnectionClosed is returned when the database connection is unexpectedly closed
 	ErrorConnectionClosed = errors.New("database connection closed")
+	// ErrorWideFrameTooLarge is returned when converting a long result to the
+	// wide time-series format would allocate more cells than the configured
+	// LongToWideCellLimit
+	ErrorWideFrameTooLarge = errors.New("time series result too large to convert to wide format")
 )
 
 func ErrorSource(err error) backend.ErrorSource {

--- a/longtowide.go
+++ b/longtowide.go
@@ -1,0 +1,144 @@
+package sqlds
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/maphash"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+// defaultLongToWideCellLimit is the projected-cell budget applied when
+// DriverSettings.LongToWideCellLimit is 0. The wide pivot allocates every
+// cell up front (null-filled), so at 8-16 bytes a cell a 10,000,000-cell
+// frame already costs 80-160MB before Arrow marshaling doubles it, which is
+// past the response sizes Grafana can deliver.
+const defaultLongToWideCellLimit = int64(10_000_000)
+
+// resolveLongToWideCellLimit maps the DriverSettings convention onto the
+// internal one: 0 means "use the default", negative means "disabled", which
+// checkLongToWideCellBudget expresses as 0.
+func resolveLongToWideCellLimit(v int64) int64 {
+	if v == 0 {
+		return defaultLongToWideCellLimit
+	}
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
+// checkLongToWideCellBudget projects the size of the wide frame that
+// data.LongToWide would build from longFrame and returns a downstream error
+// when the projection exceeds limit (in cells, rows x fields). tsSchema must
+// be longFrame's own schema, passed in so the caller's computation is
+// reused. A limit of 0 or lower disables the check.
+//
+// The projection mirrors LongToWide's own accounting: one wide row per
+// distinct timestamp (the input must be time-sorted), and one wide field per
+// value field for each distinct factor-value combination, plus the time
+// field. Nil factor values count as empty strings, exactly as LongToWide
+// treats them. Inputs LongToWide rejects itself (unsorted times, null time
+// values) pass through so its own, more precise error is the one reported;
+// the non-time and non-string-or-bool arms are defensive and unreachable,
+// since TimeSeriesSchema only classifies those field types as time or
+// factor. The walk allocates only the set of tuple hashes, at most one entry
+// per long row, always a small fraction of the long frame already held in
+// memory, and it fails fast as soon as the partial counts already exceed the
+// limit. Tuples are compared by 64-bit hash over length-prefixed values, so
+// the encoding is injective even for values containing NUL bytes and only a
+// genuine hash collision can undercount; a collision makes the guard too
+// permissive, never wrongly reject.
+func checkLongToWideCellBudget(longFrame *data.Frame, tsSchema data.TimeSeriesSchema, limit int64) error {
+	if limit <= 0 {
+		return nil
+	}
+	if tsSchema.Type != data.TimeSeriesTypeLong {
+		return nil
+	}
+	rows, err := longFrame.RowLen()
+	if err != nil || rows == 0 {
+		return nil
+	}
+	values := int64(len(tsSchema.ValueIndices))
+
+	var (
+		h          maphash.Hash
+		lenBuf     [8]byte
+		lastTime   time.Time
+		distinctTs int64
+		tuples     int64
+		seen       = make(map[uint64]struct{})
+	)
+	for i := 0; i < rows; i++ {
+		raw, ok := longFrame.ConcreteAt(tsSchema.TimeIndex, i)
+		if !ok {
+			// Null time value: LongToWide returns ErrorNullTimeValues.
+			return nil
+		}
+		t, ok := raw.(time.Time)
+		if !ok {
+			return nil
+		}
+		if i == 0 || t.After(lastTime) {
+			distinctTs++
+			lastTime = t
+		} else if t.Before(lastTime) {
+			// Unsorted input: LongToWide returns ErrorSeriesUnsorted.
+			return nil
+		}
+
+		h.Reset()
+		for _, factorIdx := range tsSchema.FactorIndices {
+			raw, _ := longFrame.ConcreteAt(factorIdx, i)
+			var strVal string
+			switch v := raw.(type) {
+			case string:
+				strVal = v
+			case bool:
+				if v {
+					strVal = "true"
+				} else {
+					strVal = "false"
+				}
+			default:
+				return nil
+			}
+			// The length prefix delimits each value exactly, so values
+			// containing NUL or separator-like bytes cannot alias across
+			// field boundaries.
+			binary.LittleEndian.PutUint64(lenBuf[:], uint64(len(strVal)))
+			_, _ = h.Write(lenBuf[:])
+			_, _ = h.WriteString(strVal)
+		}
+		key := h.Sum64()
+		if _, dup := seen[key]; !dup {
+			seen[key] = struct{}{}
+			tuples++
+		}
+
+		if exceedsCellBudget(distinctTs, tuples, values, limit) {
+			return backend.DownstreamError(fmt.Errorf(
+				"%w: at least %d timestamps and %d series with %d value fields project past the %d-cell limit; add filters or aggregation to the query, or use the table format",
+				ErrorWideFrameTooLarge, distinctTs, tuples, values, limit,
+			))
+		}
+	}
+	return nil
+}
+
+// exceedsCellBudget reports whether distinctTs * (1 + tuples*values) > limit
+// without overflowing int64. The comparisons are exact: a > limit/b under
+// integer division holds if and only if a*b > limit for positive a and b.
+func exceedsCellBudget(distinctTs, tuples, values, limit int64) bool {
+	if distinctTs <= 0 || tuples <= 0 || values <= 0 {
+		return false
+	}
+	if tuples > limit/values {
+		return true
+	}
+	perTimestamp := 1 + tuples*values
+	return distinctTs > limit/perTimestamp
+}

--- a/longtowide_test.go
+++ b/longtowide_test.go
@@ -1,0 +1,218 @@
+package sqlds
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// longTestFrame builds a time-sorted long frame with the given number of
+// distinct timestamps and series (one string factor), one float64 value
+// field, and one row per timestamp-series pair.
+func longTestFrame(timestamps, series int) *data.Frame {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var (
+		times  []time.Time
+		labels []string
+		values []float64
+	)
+	for ts := 0; ts < timestamps; ts++ {
+		for s := 0; s < series; s++ {
+			times = append(times, base.Add(time.Duration(ts)*time.Second))
+			labels = append(labels, fmt.Sprintf("series-%d", s))
+			values = append(values, float64(s))
+		}
+	}
+	return data.NewFrame("long",
+		data.NewField("time", nil, times),
+		data.NewField("label", nil, labels),
+		data.NewField("value", nil, values),
+	)
+}
+
+func TestCheckLongToWideCellBudget(t *testing.T) {
+	t.Run("under the limit passes", func(t *testing.T) {
+		// 10 timestamps x (1 + 3 series x 1 value) = 40 cells
+		frame := longTestFrame(10, 3)
+		require.NoError(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), 40))
+	})
+
+	t.Run("over the limit fails with a downstream error", func(t *testing.T) {
+		frame := longTestFrame(10, 3)
+		err := checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), 39)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrorWideFrameTooLarge))
+		assert.True(t, backend.IsDownstreamError(err))
+	})
+
+	t.Run("limit of zero disables the guard", func(t *testing.T) {
+		frame := longTestFrame(100, 100)
+		require.NoError(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), 0))
+	})
+
+	t.Run("equal timestamps count once", func(t *testing.T) {
+		// 5 timestamps x (1 + 4 series x 1 value) = 25 cells
+		frame := longTestFrame(5, 4)
+		require.NoError(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), 25))
+		require.Error(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), 24))
+	})
+
+	t.Run("multiple value fields multiply the projection", func(t *testing.T) {
+		base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		frame := data.NewFrame("long",
+			data.NewField("time", nil, []time.Time{base, base.Add(time.Second)}),
+			data.NewField("label", nil, []string{"a", "a"}),
+			data.NewField("v1", nil, []float64{1, 2}),
+			data.NewField("v2", nil, []float64{3, 4}),
+		)
+		// 2 timestamps x (1 + 1 series x 2 values) = 6 cells
+		require.NoError(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), 6))
+		require.Error(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), 5))
+	})
+
+	t.Run("bool factors count as series dimensions", func(t *testing.T) {
+		base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		frame := data.NewFrame("long",
+			data.NewField("time", nil, []time.Time{base, base}),
+			data.NewField("flag", nil, []bool{true, false}),
+			data.NewField("value", nil, []float64{1, 2}),
+		)
+		// 1 timestamp x (1 + 2 series x 1 value) = 3 cells
+		require.NoError(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), 3))
+		require.Error(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), 2))
+	})
+
+	t.Run("unsorted input passes through to LongToWide's own error", func(t *testing.T) {
+		base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		frame := data.NewFrame("long",
+			data.NewField("time", nil, []time.Time{base.Add(time.Second), base}),
+			data.NewField("label", nil, []string{"a", "b"}),
+			data.NewField("value", nil, []float64{1, 2}),
+		)
+		// The guard stops counting at the first backward time step, so a
+		// budget the ascending prefix cannot trip passes through and
+		// LongToWide reports the unsorted input itself.
+		require.NoError(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), 1000))
+		_, err := data.LongToWide(frame, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("non-long frames pass", func(t *testing.T) {
+		frame := data.NewFrame("wide",
+			data.NewField("time", nil, []time.Time{time.Now()}),
+			data.NewField("value", nil, []float64{1}),
+		)
+		require.NoError(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), 1))
+	})
+
+	t.Run("empty frames pass", func(t *testing.T) {
+		frame := data.NewFrame("long",
+			data.NewField("time", nil, []time.Time{}),
+			data.NewField("label", nil, []string{}),
+			data.NewField("value", nil, []float64{}),
+		)
+		require.NoError(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), 1))
+	})
+
+	t.Run("factor values containing NUL bytes stay distinct", func(t *testing.T) {
+		// Without length-prefixed hashing, ("\x00"*j, "\x00"*(n-1-j)) for
+		// every j serializes to the same byte stream, the guard counts one
+		// series, and LongToWide then builds n series anyway.
+		base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		const n = 6
+		var (
+			times   []time.Time
+			factorA []string
+			factorB []string
+			vals    []float64
+		)
+		for j := 0; j < n; j++ {
+			times = append(times, base)
+			factorA = append(factorA, strings.Repeat("\x00", j))
+			factorB = append(factorB, strings.Repeat("\x00", n-1-j))
+			vals = append(vals, float64(j))
+		}
+		frame := data.NewFrame("long",
+			data.NewField("time", nil, times),
+			data.NewField("a", nil, factorA),
+			data.NewField("b", nil, factorB),
+			data.NewField("value", nil, vals),
+		)
+		wide, err := data.LongToWide(frame, nil)
+		require.NoError(t, err)
+		require.Len(t, wide.Fields, 1+n)
+		// 1 timestamp x (1 + 6 series x 1 value) = 7 cells
+		require.NoError(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), 7))
+		require.Error(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), 6))
+	})
+
+	t.Run("projection matches what LongToWide builds", func(t *testing.T) {
+		frame := longTestFrame(7, 5)
+		wide, err := data.LongToWide(frame, nil)
+		require.NoError(t, err)
+		rows, err := wide.RowLen()
+		require.NoError(t, err)
+		cells := int64(rows) * int64(len(wide.Fields))
+		// 7 timestamps x (1 + 5 series x 1 value) = 42 cells
+		assert.Equal(t, int64(42), cells)
+		require.NoError(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), cells))
+		require.Error(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), cells-1))
+	})
+}
+
+func TestCheckLongToWideCellBudgetNullTime(t *testing.T) {
+	// A null time value passes through the guard so LongToWide reports its
+	// own, more precise error.
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	frame := data.NewFrame("long",
+		data.NewField("time", nil, []*time.Time{&base, nil}),
+		data.NewField("label", nil, []string{"a", "b"}),
+		data.NewField("value", nil, []float64{1, 2}),
+	)
+	// The budget must be generous enough that the guard reaches the null
+	// value instead of tripping on the ascending prefix first.
+	require.NoError(t, checkLongToWideCellBudget(frame, frame.TimeSeriesSchema(), 1000))
+	_, err := data.LongToWide(frame, nil)
+	require.ErrorIs(t, err, data.ErrorNullTimeValues)
+}
+
+func TestWithLongToWideCellLimit(t *testing.T) {
+	q := NewQuery(nil, backend.DataSourceInstanceSettings{}, nil, nil, defaultRowLimit)
+	assert.Equal(t, int64(0), q.longToWideCellLimit)
+	q.WithLongToWideCellLimit(-1)
+	assert.Equal(t, int64(-1), q.longToWideCellLimit)
+}
+
+func TestResolveLongToWideCellLimit(t *testing.T) {
+	assert.Equal(t, defaultLongToWideCellLimit, resolveLongToWideCellLimit(0))
+	assert.Equal(t, int64(0), resolveLongToWideCellLimit(-1))
+	assert.Equal(t, int64(5), resolveLongToWideCellLimit(5))
+}
+
+func TestExceedsCellBudget(t *testing.T) {
+	tests := []struct {
+		name                              string
+		distinctTs, tuples, values, limit int64
+		want                              bool
+	}{
+		{"exactly at the limit", 10, 3, 1, 40, false},
+		{"one over the limit", 10, 3, 1, 39, true},
+		{"zero counts never exceed", 0, 0, 1, 1, false},
+		{"tuples alone past the limit", 1, 11, 1, 10, true},
+		{"large values are overflow-safe", math.MaxInt64 / 2, math.MaxInt64 / 2, math.MaxInt64 / 2, math.MaxInt64, true},
+		{"max limit never trips small counts", 1000, 1000, 10, math.MaxInt64, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, exceedsCellBudget(tc.distinctTs, tc.tuples, tc.values, tc.limit))
+		})
+	}
+}

--- a/longtowide_wiring_test.go
+++ b/longtowide_wiring_test.go
@@ -1,0 +1,120 @@
+package sqlds
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// longResultDriver is a minimal database/sql driver that serves one
+// time-sorted long result (time, label, value) so getFrames can be exercised
+// with real *sql.Rows.
+type longResultDriver struct {
+	timestamps, series int
+}
+
+func (d *longResultDriver) Open(string) (driver.Conn, error) { return &longResultConn{d: d}, nil }
+
+type longResultConn struct{ d *longResultDriver }
+
+func (c *longResultConn) Prepare(string) (driver.Stmt, error) { return &longResultStmt{d: c.d}, nil }
+func (c *longResultConn) Close() error                        { return nil }
+func (c *longResultConn) Begin() (driver.Tx, error)           { return nil, errors.New("not implemented") }
+
+type longResultStmt struct{ d *longResultDriver }
+
+func (s *longResultStmt) Close() error  { return nil }
+func (s *longResultStmt) NumInput() int { return 0 }
+func (s *longResultStmt) Exec([]driver.Value) (driver.Result, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *longResultStmt) Query([]driver.Value) (driver.Rows, error) {
+	return &longResultRows{d: s.d}, nil
+}
+
+type longResultRows struct {
+	d   *longResultDriver
+	row int
+}
+
+func (r *longResultRows) Columns() []string { return []string{"time", "label", "value"} }
+func (r *longResultRows) Close() error      { return nil }
+
+func (r *longResultRows) ColumnTypeScanType(index int) reflect.Type {
+	switch index {
+	case 0:
+		return reflect.TypeOf(time.Time{})
+	case 1:
+		return reflect.TypeOf("")
+	default:
+		return reflect.TypeOf(float64(0))
+	}
+}
+
+func (r *longResultRows) Next(dest []driver.Value) error {
+	if r.row >= r.d.timestamps*r.d.series {
+		return io.EOF
+	}
+	ts := r.row / r.d.series
+	s := r.row % r.d.series
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	dest[0] = base.Add(time.Duration(ts) * time.Second)
+	dest[1] = fmt.Sprintf("series-%d", s)
+	dest[2] = float64(s)
+	r.row++
+	return nil
+}
+
+func queryLongResult(t *testing.T, name string, timestamps, series int) *sql.Rows {
+	t.Helper()
+	sql.Register(name, &longResultDriver{timestamps: timestamps, series: series})
+	db, err := sql.Open(name, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	rows, err := db.Query("select long result")
+	require.NoError(t, err)
+	return rows
+}
+
+// TestGetFramesLongToWideCellLimit exercises the guard through getFrames
+// with real sql.Rows: the time-series format must reject an over-budget long
+// result with a downstream ErrorWideFrameTooLarge before pivoting, and a
+// negative limit must disable the guard.
+func TestGetFramesLongToWideCellLimit(t *testing.T) {
+	query := &Query{RawSQL: "select long result", Format: FormatOptionTimeSeries}
+
+	t.Run("over-budget results are rejected", func(t *testing.T) {
+		// 4 timestamps x (1 + 3 series x 1 value) = 16 cells
+		rows := queryLongResult(t, "sqlds-longtowide-over", 4, 3)
+		_, err := getFrames(rows, -1, 0, 15, nil, nil, query)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrorWideFrameTooLarge))
+		assert.True(t, backend.IsDownstreamError(err))
+	})
+
+	t.Run("a negative limit disables the guard", func(t *testing.T) {
+		rows := queryLongResult(t, "sqlds-longtowide-disabled", 4, 3)
+		frames, err := getFrames(rows, -1, 0, -1, nil, nil, query)
+		require.NoError(t, err)
+		require.Len(t, frames, 1)
+		assert.Equal(t, data.TimeSeriesTypeWide, frames[0].TimeSeriesSchema().Type)
+	})
+
+	t.Run("under-budget results pivot normally", func(t *testing.T) {
+		rows := queryLongResult(t, "sqlds-longtowide-under", 4, 3)
+		frames, err := getFrames(rows, -1, 0, 16, nil, nil, query)
+		require.NoError(t, err)
+		require.Len(t, frames, 1)
+		assert.Equal(t, data.TimeSeriesTypeWide, frames[0].TimeSeriesSchema().Type)
+	})
+}

--- a/query.go
+++ b/query.go
@@ -64,7 +64,12 @@ type DBQuery struct {
 	converters      []sqlutil.Converter
 	rowLimit        int64
 	rowCapacityHint int64
-	thresholds      responseobs.Thresholds
+	// longToWideCellLimit carries DriverSettings.LongToWideCellLimit
+	// unresolved: 0 means default, negative means disabled. getFrames
+	// resolves it so DBQuery values built directly via NewQuery get the
+	// same default as those built by SQLDatasource.
+	longToWideCellLimit int64
+	thresholds          responseobs.Thresholds
 }
 
 func NewQuery(db Connection, settings backend.DataSourceInstanceSettings, converters []sqlutil.Converter, fillMode *data.FillMissing, rowLimit int64) *DBQuery {
@@ -85,6 +90,15 @@ func NewQuery(db Connection, settings backend.DataSourceInstanceSettings, conver
 // chaining after NewQuery.
 func (q *DBQuery) WithRowCapacityHint(hint int64) *DBQuery {
 	q.rowCapacityHint = hint
+	return q
+}
+
+// WithLongToWideCellLimit bounds the wide frame the time-series format
+// builds from a long result, in projected cells. 0 (the default) applies
+// the package default of 10,000,000 cells, a negative value disables the
+// guard. Returns the receiver to allow chaining after NewQuery.
+func (q *DBQuery) WithLongToWideCellLimit(limit int64) *DBQuery {
+	q.longToWideCellLimit = limit
 	return q
 }
 
@@ -163,7 +177,7 @@ func (q *DBQuery) convertRowsToFrames(ctx context.Context, rows *sql.Rows, query
 		q.metrics.CollectDuration(source, status, time.Since(start).Seconds())
 	}()
 
-	res, err := getFrames(rows, q.rowLimit, q.rowCapacityHint, q.converters, q.fillMode, query)
+	res, err := getFrames(rows, q.rowLimit, q.rowCapacityHint, q.longToWideCellLimit, q.converters, q.fillMode, query)
 	if err != nil {
 		status = StatusError
 
@@ -220,7 +234,7 @@ func (q *DBQuery) observeResponseSize(ctx context.Context, frames data.Frames, r
 // If capacity > 0, the Frame's Fields are presized via
 // sqlutil.FrameFromRowsWithCapacity to avoid per-column slice growth during
 // scanning. Passing 0 preserves the historical FrameFromRows behavior.
-func getFrames(rows *sql.Rows, limit int64, capacity int64, converters []sqlutil.Converter, fillMode *data.FillMissing, query *Query) (data.Frames, error) {
+func getFrames(rows *sql.Rows, limit int64, capacity int64, wideCellLimit int64, converters []sqlutil.Converter, fillMode *data.FillMissing, query *Query) (data.Frames, error) {
 	// Validate rows before processing to prevent panics
 	if err := validateRows(rows); err != nil {
 		backend.Logger.Error("Invalid SQL rows", "error", err.Error())
@@ -289,7 +303,10 @@ func getFrames(rows *sql.Rows, limit int64, capacity int64, converters []sqlutil
 			return nil, ErrorNoResults
 		}
 
-		if frame.TimeSeriesSchema().Type == data.TimeSeriesTypeLong {
+		if tsSchema := frame.TimeSeriesSchema(); tsSchema.Type == data.TimeSeriesTypeLong {
+			if err := checkLongToWideCellBudget(frame, tsSchema, resolveLongToWideCellLimit(wideCellLimit)); err != nil {
+				return nil, err
+			}
 			frame, err = data.LongToWide(frame, fillMode)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
The time-series format pivots long results to wide with `data.LongToWide`. The pivot allocates one cell for every timestamp and series combination, mostly null for high-cardinality data. A single query can expand a bounded long result into a multi-gigabyte wide frame and exhaust the plugin process's memory.

This change projects the wide size before the pivot runs. `checkLongToWideCellBudget` walks the long frame once and counts distinct timestamps and distinct factor tuples. When the projection exceeds `DriverSettings.LongToWideCellLimit`, the query fails with a downstream `ErrorWideFrameTooLarge` and an actionable message, before any wide-frame memory is allocated.

**Behaviour change, on by default**: the limit defaults to 10,000,000 cells for every sqlds plugin on upgrade. Queries that previously returned very large wide frames now return an error. Set `LongToWideCellLimit: -1` to restore the old behaviour, or any positive value to tune it.

Notes for the reviewer:

- The projection mirrors `LongToWide`'s accounting exactly: one wide row per distinct timestamp, one wide field per value field per distinct factor tuple, plus the time field. A test cross-checks the projection against the field count `LongToWide` actually builds.
- Tuple identity uses a 64-bit hash over length-prefixed values. A NUL-separator encoding is not injective: factor values that contain NUL bytes (legal in some databases' string types) collide and would bypass the guard. A regression test covers this construction.
- Inputs that `LongToWide` rejects itself (unsorted times, null time values) pass through the guard, so its more precise error is the one reported.
- The guard allocates at most one tuple hash per long row, always a small fraction of the long frame already held in memory.
